### PR TITLE
Make Gradle Version Dynamic in Build Action

### DIFF
--- a/.github/actions/build-apk/action.yml
+++ b/.github/actions/build-apk/action.yml
@@ -28,7 +28,6 @@ runs:
   - name: Setup Gradle
     uses: gradle/actions/setup-gradle@v3.3.2
     with:
-      gradle-version: 8.6
       cache-encryption-key: ${{ inputs.gradle-encryption-key }}
       cache-read-only: false
       cache-overwrite-existing: true


### PR DESCRIPTION
- Remove gradle-version: 8.6 from setup-gradle action
- Defer to Gradle wrapper for version management
- Reduces action maintenance when projects upgrade Gradle

Closes #24 