### PR TITLE
ci(codex): add #codex-reply workflow for review-thread follow-ups

### DIFF
--- a/.github/workflows/codex-reply.yml
+++ b/.github/workflows/codex-reply.yml
@@ -1,0 +1,187 @@
+name: Codex Review Reply
+
+on:
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: codex-reply-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  codex-reply:
+    if: |
+      startsWith(github.event.comment.body, '#codex-reply') &&
+      contains(fromJSON('["MEMBER","OWNER"]'), github.event.comment.author_association || '')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve thread context
+        id: context
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const triggerComment = context.payload.comment;
+
+            if (!pr || !triggerComment) {
+              core.setFailed('Missing pull request review comment context.');
+              return;
+            }
+
+            const comments = await github.paginate(
+              github.rest.pulls.listReviewComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100,
+              },
+            );
+
+            const rootId = triggerComment.in_reply_to_id || triggerComment.id;
+            const threadComments = comments
+              .filter((c) => c.id === rootId || c.in_reply_to_id === rootId)
+              .sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
+
+            const originalComment = threadComments.find((c) => c.id === rootId) || triggerComment;
+            const developerResponse = triggerComment.body.replace(/^#codex-reply[^\n]*\n?/i, '').trim();
+
+            const threadSummary = threadComments.map((c) => ({
+              id: c.id,
+              author: c.user?.login || 'unknown',
+              body: c.body || '',
+              created_at: c.created_at,
+              in_reply_to_id: c.in_reply_to_id || null,
+            }));
+
+            core.setOutput('pull_number', String(pr.number));
+            core.setOutput('base_sha', pr.base?.sha || '');
+            core.setOutput('head_sha', pr.head?.sha || '');
+            core.setOutput('trigger_comment_id', String(triggerComment.id));
+            core.setOutput('trigger_author', triggerComment.user?.login || 'unknown');
+            core.setOutput('developer_response', developerResponse);
+            core.setOutput('original_comment', originalComment.body || '');
+            core.setOutput('thread_summary', JSON.stringify(threadSummary));
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.context.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Fetch PR base and head
+        shell: bash
+        run: |
+          git fetch --no-tags origin ${{ steps.context.outputs.base_sha }}
+          git fetch --no-tags origin ${{ steps.context.outputs.head_sha }}
+
+      - name: Build Codex follow-up prompt
+        shell: bash
+        run: |
+          cat > /tmp/codex_reply_prompt.md <<'EOF'
+          You are reviewing a developer's response to a prior Codex review comment in a PR thread.
+          
+          Task:
+          - Evaluate whether the developer response is technically correct based on repository code and the PR diff.
+          - Return one verdict: AGREE, DISAGREE, or NEEDS_INFO.
+          - Provide concise reasoning and concrete file evidence.
+          - If evidence is ambiguous, return NEEDS_INFO and request the minimum missing proof.
+          
+          Required output format (strict JSON only, no markdown):
+          {
+            "verdict": "AGREE | DISAGREE | NEEDS_INFO",
+            "reasoning": "short explanation",
+            "evidence": [
+              {
+                "path": "relative/path",
+                "line": 123,
+                "detail": "what this line proves"
+              }
+            ],
+            "recommended_action": "what reviewer/author should do next"
+          }
+          
+          Constraints:
+          - Base conclusions on repository files and this PR diff only.
+          - Do not invent files or lines.
+          - Keep reasoning concise and technical.
+          EOF
+
+          {
+            echo ""
+            echo "PR diff boundary:"
+            echo "git diff ${{ steps.context.outputs.base_sha }}...${{ steps.context.outputs.head_sha }}"
+            echo ""
+            echo "Original codex review comment:"
+            echo "${{ steps.context.outputs.original_comment }}"
+            echo ""
+            echo "Developer response (trigger comment body without command):"
+            echo "${{ steps.context.outputs.developer_response }}"
+            echo ""
+            echo "Thread comments (JSON):"
+            echo '${{ steps.context.outputs.thread_summary }}'
+          } >> /tmp/codex_reply_prompt.md
+
+      - name: Run Codex follow-up
+        id: codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt-file: /tmp/codex_reply_prompt.md
+          sandbox: read-only
+
+      - name: Post thread reply
+        uses: actions/github-script@v7
+        env:
+          CODEX_RAW: ${{ steps.codex.outputs.final-message }}
+          PULL_NUMBER: ${{ steps.context.outputs.pull_number }}
+          COMMENT_ID: ${{ steps.context.outputs.trigger_comment_id }}
+        with:
+          script: |
+            const raw = process.env.CODEX_RAW || '';
+            let verdict = 'NEEDS_INFO';
+            let reasoning = 'Codex reply was not parseable.';
+            let evidence = [];
+            let recommendedAction = 'Please re-run #codex-reply with additional context.';
+
+            try {
+              const parsed = JSON.parse(raw);
+              verdict = parsed.verdict || verdict;
+              reasoning = parsed.reasoning || reasoning;
+              evidence = Array.isArray(parsed.evidence) ? parsed.evidence : [];
+              recommendedAction = parsed.recommended_action || recommendedAction;
+            } catch (err) {
+              reasoning = `Codex output was not valid JSON. Raw output preserved below.\n\n${raw}`;
+            }
+
+            const evidenceLines = evidence
+              .filter((e) => e && e.path && Number.isInteger(e.line))
+              .map((e) => `- \`${e.path}:${e.line}\` - ${e.detail || ''}`);
+
+            const footer = verdict === 'AGREE'
+              ? 'If this addresses your concern, please mark this thread as resolved.'
+              : '';
+
+            const body = [
+              `Codex follow-up verdict: **${verdict}**`,
+              '',
+              reasoning,
+              '',
+              evidenceLines.length ? '**Evidence**' : '',
+              ...evidenceLines,
+              evidenceLines.length ? '' : '',
+              `**Recommended action**: ${recommendedAction}`,
+              footer,
+            ].filter(Boolean).join('\n');
+
+            await github.rest.pulls.createReplyForReviewComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(process.env.PULL_NUMBER),
+              comment_id: Number(process.env.COMMENT_ID),
+              body,
+            });


### PR DESCRIPTION
Add a dedicated workflow triggered by pull_request_review_comment when a member/owner comment starts with #codex-reply.

The workflow gathers review-thread context, asks Codex for a structured AGREE/DISAGREE/NEEDS_INFO verdict with file evidence, and posts a reply to the same review thread.

Only AGREE replies include the resolution prompt: 'If this addresses your concern, please mark this thread as resolved.'