### PR TITLE
ci(codex): allow collaborator association for #codex-reply trigger

### DIFF
--- a/.github/workflows/codex-reply.yml
+++ b/.github/workflows/codex-reply.yml
@@ -16,7 +16,7 @@ jobs:
   codex-reply:
     if: |
       startsWith(github.event.comment.body, '#codex-reply') &&
-      contains(fromJSON('["MEMBER","OWNER"]'), github.event.comment.author_association || '')
+      contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association || '')
     runs-on: ubuntu-latest
     steps:
       - name: Resolve thread context


### PR DESCRIPTION
Update codex-reply workflow gate to accept COLLABORATOR in addition to MEMBER/OWNER so valid review-thread commands from collaborator-associated users are not skipped.