### PR TITLE
ci(codex-reply): scope concurrency by review comment id

### DIFF
--- a/.github/workflows/codex-reply.yml
+++ b/.github/workflows/codex-reply.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: codex-reply-${{ github.event.pull_request.number || github.run_id }}
+  group: codex-reply-${{ github.event.comment.id || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Update concurrency group to use github.event.comment.id so #codex-reply runs on different review comments do not cancel each other.

Keep cancel-in-progress enabled to deduplicate repeated triggers on the same comment.