### PR TITLE
Fix audit LAST_100 jq parsing in workflow

### DIFF
--- a/.github/workflows/issue-milestone-audit-log.yml
+++ b/.github/workflows/issue-milestone-audit-log.yml
@@ -98,14 +98,14 @@ jobs:
             tail -n 100 audit/events.ndjson | jq -r '
               def issue_text:
                 if .issue == null then "-"
-                else "#\(.issue.number) \(.issue.title // \"\")"
+                else "#\(.issue.number) \(.issue.title // "")"
                 end;
 
               def milestone_text:
                 if .milestone != null then
-                  "#\(.milestone.number) \(.milestone.title // \"\")"
+                  "#\(.milestone.number) \(.milestone.title // "")"
                 elif (.issue != null and .issue.milestone != null) then
-                  "#\(.issue.milestone.number) \(.issue.milestone.title // \"\")"
+                  "#\(.issue.milestone.number) \(.issue.milestone.title // "")"
                 else "-"
                 end;
 


### PR DESCRIPTION
## Summary
Fix jq parsing in the audit workflow's human-readable LAST_100 generator.

## What changed
- Updated `.github/workflows/issue-milestone-audit-log.yml`
- Replaced invalid escaped empty-string defaults inside the single-quoted jq program:
  - `\"\"` -> `""`
- This prevents jq compile failures in the `Build human-readable last 100 events` step.

## Why
Workflow was failing with:
- `jq: syntax error, unexpected INVALID_CHARACTER`
- `Possibly unterminated 'if' statement`

## Result
The LAST_100 markdown generation step now parses and runs successfully.
