### PR TITLE
PermissionHandlingUpdates:: Moving onSerialReady to Dispatchers.Default

### DIFF
--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/AbcvlibActivity.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/AbcvlibActivity.kt
@@ -6,12 +6,17 @@ import android.os.Bundle
 import android.view.WindowManager
 import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import jp.oist.abcvlib.core.outputs.Outputs
 import jp.oist.abcvlib.util.Logger
 import jp.oist.abcvlib.util.ProcessPriorityThreadFactory
 import jp.oist.abcvlib.util.SerialCommManager
 import jp.oist.abcvlib.util.SerialReadyListener
 import jp.oist.abcvlib.util.UsbSerial
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
 import java.io.IOException
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -35,6 +40,7 @@ abstract class AbcvlibActivity : AppCompatActivity(), SerialReadyListener {
     private var pi2AndroidReader: Runnable? = null
     private var alertDialog: AlertDialog? = null
     private var initialDelay: Long = 0
+    private var serialReadyJob: Job? = null
 
     // Note anything less than 10ms will result in no GET_STATE commands being called and all
     // being overrides by whatever commands are sent in the main loop
@@ -51,7 +57,22 @@ abstract class AbcvlibActivity : AppCompatActivity(), SerialReadyListener {
     private fun usbInitialize() {
         try {
             val usbManager = getSystemService(USB_SERVICE) as UsbManager
-            this.usbSerial = UsbSerial(this, usbManager, this)
+            this.usbSerial = UsbSerial(
+                context = this,
+                usbManager = usbManager,
+                serialReadyListener = object : SerialReadyListener {
+                    override fun onSerialReady(usbSerial: UsbSerial) {
+                        lifecycleScope.launch {
+                            // Cancel the previous serialReadyJob if it exists to avoid multiple executions in parallel.
+                            serialReadyJob?.cancelAndJoin()
+                            // Call Activity's onSerialReady inside (Dispatchers.Default) to avoid blocking the main thread
+                            serialReadyJob = launch(Dispatchers.Default) {
+                                this@AbcvlibActivity.onSerialReady(usbSerial)
+                            }
+                        }
+                    }
+                }
+            )
         } catch (e: IOException) {
             e.printStackTrace()
             showCustomDialog()


### PR DESCRIPTION
## Summary
- What is in scope for this PR?
- What is intentionally out of scope?
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `milestone/PermissionHandlingUpdates`
- This PR branch: `PermissionHandlingUpdates/Use-Coroutines`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [x] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/PermissionHandlingUpdates.md`

## Scope Declaration
- Exact slice/module in this PR:
  - `libs/abcvlib/src/main/java/jp/oist/abcvlib/core/AbcvlibActivity.kt`
  
Resolves #14, Resolves  #170
