### PR TITLE
Adding initial state to prevent Issue #172

### DIFF
--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/Publisher.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/Publisher.kt
@@ -44,7 +44,7 @@ abstract class Publisher<T : Subscriber>(
 ) : PermissionRequestListener {
     protected var subscribers: ArrayList<T> = ArrayList()
 
-    private lateinit var state: PublisherState
+    private var state: PublisherState = PublisherState.STOPPED
     protected val permissionManager: PermissionManager
     protected lateinit var mHandlerThread: HandlerThread
     protected lateinit var handler: Handler


### PR DESCRIPTION
## Summary
- What is in scope for this PR?
Just a quick fix to prevent runtime crash on basicAssembler. Without this [PR#171](github.com/tekkura/sr-android/pull/171) can't be tested against runtime as it crashes before the changes occur. 

- What is intentionally out of scope?
- [X ] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `milestone/[milestone-name]`
- This PR branch: `[milestone-name]/[feature-branch]`
- [X] Branch naming follows the required convention.
- [X] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [X] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/PermissionHandlingUpdates.md`

## Scope Declaration
- Exact slice/module in this PR:
  -`libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/Publisher.kt`
- Related sibling PRs/issues (remaining slices), if any:
  -[PR#171](github.com/tekkura/sr-android/pull/171)
  - Issue https://github.com/tekkura/sr-android/issues/172
