### PR TITLE
PermissionHandlingUpdates: Add HIGH_SAMPLING_RATE_SENSORS permission

### DIFF
--- a/libs/abcvlib/src/main/AndroidManifest.xml
+++ b/libs/abcvlib/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/>
 
     <uses-feature android:name="android.hardware.usb.accessory" />
     <uses-feature android:name="android.hardware.camera.any" />


### PR DESCRIPTION
## Summary
- This PR fixes `java.lang.SecurityException` on **Android 12+** when the app using `OrientationData` tries to access high-frequency sensor data.
- It adds the `HIGH_SAMPLING_RATE_SENSORS` permission in `AndroidManifest.xml` to allow the requested sensor sampling rate.
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `milestone/PermissionHandlingUpdates`
- This PR branch: `PermissionHandlingUpdates/Fix-SensorManager-Permissions`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [x] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/PermissionHandlingUpdates.md`

## Scope Declaration
- Exact slice/module in this PR:
  - `libs/abcvlib/src/main/AndroidManifest.xml`

Closes #175 
