### PR TITLE
fix(serial): harden SerialCommManager lifecycle and synchronization

### DIFF
--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/SerialCommManager.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/SerialCommManager.kt
@@ -57,23 +57,27 @@ class SerialCommManager @JvmOverloads constructor(
     private fun buildAndroid2PiWriter(context: RunContext): Runnable = Runnable {
         startTimeAndroid = System.nanoTime()
         while (!context.stopRequested.get()) {
-            synchronized(commandLock) {
-                try {
+            val nextCommand: ByteArray? = try {
+                synchronized(commandLock) {
                     // this results in getState commands every 10ms unless another command
                     // (e.g. setMotorLevels) is set, which case wait will return immediately
                     commandLock.wait(10)
                     if (context.stopRequested.get()) {
-                        break
+                        return@synchronized null
                     }
-                    if (command == null) {
-                        command = generateGetStateCmd()
-                    }
-                    sendPacket(command!!)
+                    val localCommand = command ?: generateGetStateCmd()
                     command = null
-                } catch (e: InterruptedException) {
-                    e.printStackTrace()
+                    localCommand
                 }
+            } catch (e: InterruptedException) {
+                continue
             }
+
+            if (nextCommand == null) {
+                break
+            }
+
+            sendPacket(nextCommand)
             cnt++
             if (cnt == 100) {
                 durationAndroid = (System.nanoTime() - startTimeAndroid) / 100
@@ -126,10 +130,6 @@ class SerialCommManager @JvmOverloads constructor(
             context.stopRequested.set(true)
             context.writerExecutor?.shutdownNow()
             context.writerExecutor = null
-            synchronized(commandLock) {
-                command = null
-                commandLock.notifyAll()
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
- What is in scope for this PR?
  - Thread-safety hardening inside `SerialCommManager` lifecycle and command enqueue paths.
- What is intentionally out of scope?
  - No behavior/migration-guide changes to app-level initialization flow in `AbcvlibActivity`.
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `milestone/PermissionHandlingUpdates`
- This PR branch: `PermissionHandlingUpdates/serial-manager-threadsafe`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [x] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/PermissionHandlingUpdates.md`

## Scope Declaration
- Exact slice/module in this PR:
  - `libs/abcvlib/src/main/java/jp/oist/abcvlib/util/SerialCommManager.kt`
- Related sibling PRs/issues (remaining slices), if any:
  - `https://github.com/tekkura/sr-android/pull/177`
