### PR TITLE
docs(migration): allow required permission/lifecycle supporting changes

### DIFF
--- a/docs/migrations/PermissionHandlingUpdates.md
+++ b/docs/migrations/PermissionHandlingUpdates.md
@@ -5,15 +5,20 @@
 
 ## Objective
 - Use Kotlin Coroutines to prevent main thread blocking and ensure smooth, asynchronous publisher initialization.
-- Centralize this improvement in the base activity (AbcvlibActivity) to ensure consistent behavior across the application.
+- Centralize permission-handling behavior as much as possible while allowing required supporting changes in dependent permission/lifecycle paths.
 
 ## Scope
-- Files affected: `AbcvlibActivity`.
+- Primary file: `AbcvlibActivity`.
+- Allowed supporting files:
+  - Directly related permission/lifecycle plumbing required to make permission-handling robust (for example `SerialCommManager` when needed for sequencing/thread-safety tied to permission flow).
+  - `AndroidManifest.xml` permission declarations required for this milestone's runtime permission behavior.
 
 ## Rules
 - Move `AbcvlibActivity.onSerialReady` context to `Dispatchers.Default`.
 - Maintain concurrency behavior: moving code to coroutines must not introduce race conditions.
 - Launch coroutines exclusively from `AbcvlibActivity`.
+- Manifest edits in this milestone must be limited to permission declarations only.
+- Changes outside permission-handling/lifecycle correctness are out of scope.
 
 ## Test/Validation Expectations for PR Acceptance
 - At runtime, a newly installed app must:


### PR DESCRIPTION
## Summary
- What is in scope for this PR?
  - Update the PermissionHandlingUpdates migration guide so scope allows required permission/lifecycle supporting changes outside `AbcvlibActivity`.
  - Explicitly allow Android manifest permission declaration updates when required by this milestone.
- What is intentionally out of scope?
  - No code changes; no non-permission functional changes.
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `milestone/PermissionHandlingUpdates`
- This PR branch: `PermissionHandlingUpdates/update-migration-scope`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [x] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/PermissionHandlingUpdates.md`

## Scope Declaration
- Exact slice/module in this PR:
  - `docs/migrations/PermissionHandlingUpdates.md`
- Related sibling PRs/issues (remaining slices), if any:
  - `https://github.com/tekkura/sr-android/pull/177`
  - `https://github.com/tekkura/sr-android/pull/178`
