### PR TITLE
PermissionHandlingUpdates: Add @WorkerThread annotations to non-UI methods

### DIFF
--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/AbcvlibActivity.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/AbcvlibActivity.kt
@@ -5,6 +5,7 @@ import android.hardware.usb.UsbManager
 import android.os.Bundle
 import android.view.WindowManager
 import android.widget.Button
+import androidx.annotation.WorkerThread
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import jp.oist.abcvlib.core.outputs.Outputs
@@ -79,6 +80,7 @@ abstract class AbcvlibActivity : AppCompatActivity(), SerialReadyListener {
         }
     }
 
+    @WorkerThread
     override fun onSerialReady(usbSerial: UsbSerial) {
         if (serialCommManager == null) {
             Logger.w(
@@ -105,11 +107,13 @@ abstract class AbcvlibActivity : AppCompatActivity(), SerialReadyListener {
         }
     }
 
+    @WorkerThread
     protected open fun abcvlibMainLoop() {
         // Throw runtime error if this is called and indicate to user that this needs to be overridden
         throw RuntimeException("runAbcvlibActivityMainLoop must be overridden")
     }
 
+    @WorkerThread
     protected open fun onOutputsReady() {
         // Override this method in your MainActivity to do anything that requires the outputs
         Logger.w(


### PR DESCRIPTION
## Summary
This PR Adds `@WorkerThread` annotation to `onSerialReady`, `onOutputsReady` and `abcvlibMainLoop` to prevent users from performing UI operations directly in these methods.
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `milestone/PermissionHandlingUpdates`
- This PR branch: `PermissionHandlingUpdates/worker-thread-annotations`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [x] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/PermissionHandlingUpdates.md`

## Scope Declaration
- Exact slice/module in this PR:
  - `abcvlib/core/AbcvlibActivity.kt`
- Related sibling PRs/issues (remaining slices), if any:
  - (https://github.com/tekkura/sr-android/pull/177)
