### PR TITLE
ci: avoid release signing in PR build checks

### DIFF
--- a/.github/actions/build-apk/action.yml
+++ b/.github/actions/build-apk/action.yml
@@ -1,5 +1,5 @@
 name: 'Build'
-description: 'Combines checkout, openjdk17 install, setup-gradle, and gradle build into one'
+description: 'Combines checkout, openjdk17 install, setup-gradle, and a configurable Gradle invocation into one'
 inputs:
   gradle-encryption-key:
     description: 'The encryption key to use for caching'
@@ -10,6 +10,10 @@ inputs:
   github-token:
     description: 'GitHub token for authentication'
     required: true
+  gradle-command:
+    description: 'Gradle task list to run'
+    required: false
+    default: 'build'
 runs:
   using: "composite"
   steps:
@@ -32,7 +36,7 @@ runs:
       cache-read-only: false
       cache-overwrite-existing: true
   - name: Build with Gradle
-    run: ./gradlew build
+    run: ./gradlew ${{ inputs.gradle-command }}
     shell: bash
     env:
       GITHUB_USER: ${{ inputs.github-user }}

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Build
       with:
         gradle-encryption-key: ${{ secrets.GradleEncryptionKey }}
+        gradle-command: assembleDebug testDebugUnitTest lintDebug
         github-user: ${{ github.actor }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
       uses: ./.github/actions/build-apk


### PR DESCRIPTION
## Summary
- In scope: make PR build checks run debug-only validation so they do not require release signing inputs.
- In scope: keep the shared build action reusable by making the Gradle task list configurable.
- Out of scope: automated release signing, keystore decoding, and release workflow behavior.
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `main` (temporary validation target to trigger `build-check`)
- This PR branch: `buildCheckUpdates`
- [ ] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [ ] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/AppSigning.md`

## Scope Declaration
- Exact slice/module in this PR:
  - `.github/actions/build-apk`
  - `.github/workflows/build-check.yml`
- Related sibling PRs/issues (remaining slices), if any:
  - Canonical PR against implementation branch: #186

## Verification
- `./gradlew -m assembleDebug testDebugUnitTest lintDebug`
- `./gradlew assembleDebug testDebugUnitTest lintDebug`
