### PR TITLE
Fixed typo in TensorFlowLite2LiteRT.md (MediaPipe version)

### DIFF
--- a/docs/migrations/TensorFlowLite2LiteRT.md
+++ b/docs/migrations/TensorFlowLite2LiteRT.md
@@ -18,7 +18,7 @@ MediaPipe contains LiteRT so no additional explicit LiteRT dependencies are requ
 
 ### Phase 2: Dependency Migration
 - **Update `libs.versions.toml`**:
-    - Replace `org.tensorflow:tensorflow-lite-*` with `com.google.mediapipe:tasks-vision` as recommended by Google (see below). Use version 0.10.33
+    - Replace `org.tensorflow:tensorflow-lite-*` with `com.google.mediapipe:tasks-vision` as recommended by Google (see below). Use version 0.10.32
 - **Update module-level `build.gradle.kts`**:
     - Update dependency references to use the new MediaPipe entries.
 


### PR DESCRIPTION
## Summary
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `milestone/TensorFlowLite2LiteRT`
- This PR branch: `TensorFlowLite2LiteRT/lib-version-fix`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [x] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/TensorFlowLite2LiteRT.md`

## Scope Declaration
- Exact slice/module in this PR:
  - `docs/migrations/TensorFlowLite2LiteRT`
- Related sibling PRs/issues (remaining slices), if any:
  - none
