### PR TITLE
Clarify README JitPack dependency guidance for abcvlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # OIST Smartphone Robot Android Framework
+[![](https://jitpack.io/v/oist/smartphone-robot-android.svg)](https://jitpack.io/#oist/smartphone-robot-android)
 
 The main purpose of this repo is to host the abcvlib development. This is the library governing the OIST Smartphone Robot Android Framework. The framework is designed to provide a simple and easy to use interface for developing Android applications for the OIST Smartphone Robot.
 
@@ -135,14 +136,17 @@ Add the JitPack repository to your Gradle build:
 repositories {
     maven { url = uri("https://jitpack.io") }
 }
-```
 
-Then use the dependency coordinates shown on the JitPack page for the release tag you want to consume.
+dependencies {
+    implementation("com.github.oist.smartphone-robot-android:abcvlib:v2.0.2")
+}
+```
 
 Notes:
 
 - Public consumers do not need GitHub Packages credentials to depend on `abcvlib` through JitPack.
 - Repository-owned publishing workflows may still use GitHub Packages separately from this consumer setup.
+- JitPack consumption uses the repository/module coordinate `com.github.oist.smartphone-robot-android:abcvlib:<tag>`.
+- This consumer coordinate is separate from the repository-owned Maven publication metadata used elsewhere in the build.
 - Git release tags use the form `vX.Y.Z`.
 - The published Maven version is normalized from `vX.Y.Z` to `X.Y.Z` by the checked-in build logic.
-- Use the exact dependency snippet shown for the chosen tag on JitPack rather than assuming a `com.github...` coordinate format.


### PR DESCRIPTION
## Summary
- In scope: fix the README guidance for public `abcvlib` consumption so it shows a concrete tested JitPack dependency example and explains the coordinate format.
- Out of scope: changing the publication/build configuration itself.
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `milestone/APKDistribution`
- This PR branch: `APKDistribution/readmeUpdates`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [x] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/APKDistribution.md`

## Scope Declaration
- Exact slice/module in this PR:
  - `README.md` JitPack dependency guidance for `abcvlib`
- Related sibling PRs/issues (remaining slices), if any:
  - [PR #203](https://github.com/tekkura/sr-android/pull/203)
  - [PR #199](https://github.com/tekkura/sr-android/pull/199)
  - [Issue #195](https://github.com/tekkura/sr-android/issues/195)
  - [Issue #196](https://github.com/tekkura/sr-android/issues/196)