### PR TITLE
Update object detection model download to 2.0.0

### DIFF
--- a/build-logic/convention/src/main/kotlin/jp/oist/abcvlib/ModelDownload.kt
+++ b/build-logic/convention/src/main/kotlin/jp/oist/abcvlib/ModelDownload.kt
@@ -7,7 +7,7 @@ import org.gradle.kotlin.dsl.register
 object ModelDownload {
 
     private val models = mapOf(
-        "model.tflite" to "https://github.com/oist/smartphone-robot-object-detection/releases/download/0.1.1/model.tflite",
+        "model.tflite" to "https://github.com/oist/smartphone-robot-object-detection/releases/download/2.0.0/smartphone-robot-detector-2.0.0-3-class.tflite",
         "efficientdet-lite0.tflite" to "https://storage.googleapis.com/download.tensorflow.org/models/tflite/task_library/object_detection/android/lite-model_efficientdet_lite0_detection_metadata_1.tflite",
         "efficientdet-lite1.tflite" to "https://storage.googleapis.com/download.tensorflow.org/models/tflite/task_library/object_detection/android/lite-model_efficientdet_lite1_detection_metadata_1.tflite"
     )
@@ -22,7 +22,7 @@ object ModelDownload {
                 tasks.register<Download>("download_${name.replace(".", "_")}") {
                     src(url)
                     dest("$assetDir/$name")
-                    overwrite(false)
+                    overwrite(name == "model.tflite")
                 }
             }
 


### PR DESCRIPTION
## Summary
Update the shared Android model download to use the  object-detection release asset.

## Changes
- point  at the   release asset
- keep downloading to the local asset name 
- overwrite the local  on download so stale assets from older branches or runs do not persist

## Verification
- Starting a Gradle Daemon, 1 incompatible and 1 stopped Daemons could not be reused, use --status for details
> Task :build-logic:convention:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :build-logic:convention:compileKotlin UP-TO-DATE
> Task :build-logic:convention:compileJava NO-SOURCE
> Task :build-logic:convention:pluginDescriptors UP-TO-DATE
> Task :build-logic:convention:processResources UP-TO-DATE
> Task :build-logic:convention:classes UP-TO-DATE
> Task :build-logic:convention:jar UP-TO-DATE

> Configure project :abcvlib
networkConfig - ip: 192.168.1.1, port: 3000

> Configure project :backAndForth
versionName = 1.3.2-284-clean
versionCode = 132284

> Configure project :backAndForthPython
versionName = 1.3.2-284-clean
versionCode = 132284

> Configure project :basicAssembler
versionName = 1.3.2-284-clean
versionCode = 132284

> Configure project :basicCharger
versionName = 1.3.2-284-clean
versionCode = 132284

> Configure project :basicQRReceiver
versionName = 1.3.2-284-clean
versionCode = 132284

> Configure project :basicQRTransmitter
versionName = 1.3.2-284-clean
versionCode = 132284

> Configure project :basicServer
versionName = 1.3.2-284-clean
versionCode = 132284

> Configure project :basicSubscriber
versionName = 1.3.2-284-clean
versionCode = 132284

> Configure project :basicSubscriberPython
versionName = 1.3.2-284-clean
versionCode = 132284

> Configure project :handsOnApp
versionName = 1.3.2-284-clean
versionCode = 132284

> Configure project :pidBalancer
versionName = 1.3.2-284-clean
versionCode = 132284

> Task :abcvlib:download_efficientdet-lite0_tflite UP-TO-DATE
> Task :abcvlib:download_efficientdet-lite1_tflite UP-TO-DATE

> Task :abcvlib:download_model_tflite
Download https://github.com/oist/smartphone-robot-object-detection/releases/download/2.0.0/smartphone-robot-detector-2.0.0-3-class.tflite

> Task :abcvlib:downloadModelFiles

BUILD SUCCESSFUL in 26s
7 actionable tasks: 1 executed, 6 up-to-date
- runtime sanity check with  completed without crash