### PR TITLE
Add Docker support for isolated ROS smoke testing

### DIFF
--- a/docker/rosbridge/Dockerfile
+++ b/docker/rosbridge/Dockerfile
@@ -2,6 +2,7 @@ FROM ros:kilted-ros-base
 
 RUN apt-get update && apt-get install -y \
     ros-${ROS_DISTRO}-rosbridge-suite \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
     && rm -rf /var/lib/apt/lists/*
 
 CMD ["bash", "-lc", "source /opt/ros/$ROS_DISTRO/setup.bash && ros2 launch rosbridge_server rosbridge_websocket_launch.xml"]

--- a/docker/rosbridge/docker-compose.yml
+++ b/docker/rosbridge/docker-compose.yml
@@ -1,10 +1,13 @@
 services:
   rosbridge:
     build:
-      context: ../..
-      dockerfile: docker/rosbridge/Dockerfile
+      context: .
+      dockerfile: Dockerfile
     environment:
       ROS_DISTRO: kilted
+      ROS_DOMAIN_ID: "0"
+      ROS_AUTOMATIC_DISCOVERY_RANGE: LOCALHOST
+      RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
     ports:
       - "9090:9090"
     command: >
@@ -14,10 +17,13 @@ services:
 
   pub:
     build:
-      context: ../..
-      dockerfile: docker/rosbridge/Dockerfile
+      context: .
+      dockerfile: Dockerfile
     environment:
       ROS_DISTRO: kilted
+      ROS_DOMAIN_ID: "0"
+      ROS_AUTOMATIC_DISCOVERY_RANGE: LOCALHOST
+      RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
     network_mode: "service:rosbridge"
     command: >
       bash -lc
@@ -26,10 +32,13 @@ services:
 
   echo:
     build:
-      context: ../..
-      dockerfile: docker/rosbridge/Dockerfile
+      context: .
+      dockerfile: Dockerfile
     environment:
       ROS_DISTRO: kilted
+      ROS_DOMAIN_ID: "0"
+      ROS_AUTOMATIC_DISCOVERY_RANGE: LOCALHOST
+      RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
     network_mode: "service:rosbridge"
     command: >
       bash -lc

--- a/docs/ros/Smoke_Test.md
+++ b/docs/ros/Smoke_Test.md
@@ -13,6 +13,14 @@ Verifies that the Android app can connect to `rosbridge`, subscribe to a topic, 
   ```powershell
   netsh advfirewall firewall add rule name="ROS Bridge 9090" dir=in action=allow protocol=TCP localport=9090
   ```
+  Then forward port 9090 from Windows to WSL2 (run as Administrator):
+  ```powershell
+  # Get the WSL2 IP
+  wsl hostname -I
+  # Use the first IP returned (e.g. 172.x.x.x)
+  netsh interface portproxy add v4tov4 listenport=9090 listenaddress=0.0.0.0 connectport=9090 connectaddress=<WSL_IP>
+  ```
+  > **Note:** The WSL2 IP may change on reboot. Re-run `wsl hostname -I` and update the rule if the Android app can no longer connect.
 - Android device and PC on the same LAN
 - Android app built and installed on the device
 
@@ -28,6 +36,13 @@ Run these commands from the repo root.
 The provided compose file already pins `ROS_DISTRO=kilted`, so no extra host environment setup is required.
 The rosbridge service publishes TCP port `9090` to the host, so the Android phone should connect to
 the PC's LAN IP on port `9090`.
+
+**All-in-one — start all services together:**
+```bash
+sudo docker compose -f docker/rosbridge/docker-compose.yml up --build
+```
+
+Or start each service in a separate terminal for easier debugging:
 
 **Terminal 1 — start rosbridge:**
 ```bash
@@ -88,7 +103,13 @@ ros2 topic echo /test_from_android std_msgs/msg/String
 [RosBridge] Subscribed to /test_from_ros
 [RosBridge] Received: hello from ros
 [RosBridge] Published to /test_from_android
-[SmokeTest] PASS: connect=OK  subscribe=OK  publish=OK
+```
+
+**Android logcat — failure examples:**
+```
+[RosBridge] ERROR: Unable to resolve host "192.168.x.xx": No address associated with hostname
+[RosBridge] ERROR: Connection reset
+[RosBridge] ERROR: Failed to parse message
 ```
 
 **Terminal 3 (PC) — pass:**
@@ -96,14 +117,10 @@ ros2 topic echo /test_from_android std_msgs/msg/String
 data: hello from android
 ```
 
-**Android logcat — failure examples:**
+**Terminal 1 (PC) — failure:**
 ```
-[RosBridge] ERROR: Connection failed — check PC IP and rosbridge is running
-[RosBridge] ERROR: No message received on /test_from_ros — check Terminal 2 is publishing
-[RosBridge] ERROR: Publish failed — WebSocket not connected
-[SmokeTest] FAIL: connect=FAIL  subscribe=SKIP  publish=SKIP
+[rosbridge_websocket]: publish: Cannot infer topic type for topic /test_from_android as it is not yet advertised
 ```
-
 ---
 
 ## Pass Criteria
@@ -112,4 +129,4 @@ data: hello from android
 |---|---|
 | Connect | WebSocket handshake succeeds, no error log |
 | Subscribe | At least one message received on `/test_from_ros` |
-| Publish | Message appears in Terminal 3 on the PC |
+| Publish | Message appears on `/test_from_android` topic|


### PR DESCRIPTION
## Summary
- In scope: add a repo-local Docker image and compose workflow for rosbridge smoke testing, and update `docs/ros/Smoke_Test.md` to use that isolated setup.
- Out of scope: changes to the `rosbridgeTest` Android app itself, including the broken publish path that still needs an `advertise` step before `publish`.
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `milestone/ROS`
- This PR branch: `ROS/docker`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [x] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/ROS.md`

## Scope Declaration
- Exact slice/module in this PR:
  - `docker/rosbridge/*`
  - `docs/ros/Smoke_Test.md`
- Related sibling PRs/issues (remaining slices), if any:
  - ROS smoke-test app PR still needs the `/test_from_android` advertise-before-publish fix.
