### PR TITLE
Support colored QR rendering in shared QR utilities

### DIFF
--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/fragments/QRCodeDisplayFragment.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/fragments/QRCodeDisplayFragment.kt
@@ -20,7 +20,8 @@ import java.util.EnumMap
 import androidx.core.graphics.createBitmap
 
 class QRCodeDisplayFragment(
-    private val data2Encode: String
+    private val data2Encode: String,
+    private val foregroundColor: Int
 ) : Fragment(R.layout.q_r_code_display) {
 
     companion object {
@@ -68,7 +69,7 @@ class QRCodeDisplayFragment(
         for (y in 0..<height) {
             val offset = y * width
             for (x in 0..<width) {
-                pixels[offset + x] = if (result.get(x, y)) Color.BLACK else Color.WHITE
+                pixels[offset + x] = if (result.get(x, y)) foregroundColor else Color.WHITE
             }
         }
 

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/QRCode.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/QRCode.kt
@@ -1,5 +1,6 @@
 package jp.oist.abcvlib.util
 
+import android.graphics.Color
 import androidx.fragment.app.FragmentManager
 import jp.oist.abcvlib.fragments.QRCodeDisplayFragment
 
@@ -9,21 +10,29 @@ class QRCode(
 ) {
     private var codeVisible = false
 
-    fun generate(data2Encode: String) {
-        val qrCodeDisplayFragment = QRCodeDisplayFragment(data2Encode)
+    fun generate(data2Encode: String, foregroundColor: Int = Color.BLACK) {
+        val qrCodeDisplayFragment = QRCodeDisplayFragment(data2Encode, foregroundColor)
         fragmentManager.beginTransaction()
-            .replace(fragmentViewID, qrCodeDisplayFragment)
+            .replace(fragmentViewID, qrCodeDisplayFragment, FRAGMENT_TAG)
             .setReorderingAllowed(true)
-            .addToBackStack("qrCode")
             .commit()
         codeVisible = true
     }
 
     fun close() {
-        if (codeVisible) {
-            fragmentManager.popBackStack()
-        } else {
+        val qrCodeDisplayFragment = fragmentManager.findFragmentByTag(FRAGMENT_TAG)
+        if (qrCodeDisplayFragment == null) {
             Logger.e("QRCode", "Attempted to close nonexistent QR Code")
+            return
         }
+        fragmentManager.beginTransaction()
+            .remove(qrCodeDisplayFragment)
+            .setReorderingAllowed(true)
+            .commit()
+        codeVisible = false
+    }
+
+    private companion object {
+        private const val FRAGMENT_TAG = "qrCode"
     }
 }


### PR DESCRIPTION
## Summary
- In scope: split the shared QR utility changes out of the comprehensiveDemo scaffold work by updating the `abcvlib` QR helper and display fragment to support colored QR rendering and stable fragment replacement.
- Out of scope: any `comprehensiveDemo` app/controller behavior, QR payload semantics, or other app-specific logic.
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `main`
- This PR branch: `QRCodeUpdates`
- [ ] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [ ] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/comprehensiveDemo.md`

## Scope Declaration
- Exact slice/module in this PR:
  - `libs/abcvlib/src/main/java/jp/oist/abcvlib/util/QRCode.kt`
  - `libs/abcvlib/src/main/java/jp/oist/abcvlib/fragments/QRCodeDisplayFragment.kt`
- Related sibling PRs/issues (remaining slices), if any:
  - `comprehensiveDemo/app-scaffold`
