### PR TITLE
Split object detection timing and latency tracing updates

### DIFF
--- a/apps/basicCharger/src/main/java/jp/oist/abcvlib/basiccharger/MainActivity.kt
+++ b/apps/basicCharger/src/main/java/jp/oist/abcvlib/basiccharger/MainActivity.kt
@@ -198,6 +198,9 @@ class MainActivity : AbcvlibActivity(), SerialReadyListener, BatteryDataSubscrib
         mpImage: MPImage,
         results: MutableList<Detection>,
         inferenceTime: Long,
+        frameCapturedAtNs: Long,
+        detectStartedAtNs: Long,
+        detectCompletedAtNs: Long,
         height: Int,
         width: Int
     ) {

--- a/apps/basicSubscriber/src/main/java/jp/oist/abcvlib/basicsubscriber/MainActivity.kt
+++ b/apps/basicSubscriber/src/main/java/jp/oist/abcvlib/basicsubscriber/MainActivity.kt
@@ -223,6 +223,9 @@ class MainActivity : AbcvlibActivity(), SerialReadyListener, BatteryDataSubscrib
         mpImage: MPImage,
         results: MutableList<Detection>,
         inferenceTime: Long,
+        frameCapturedAtNs: Long,
+        detectStartedAtNs: Long,
+        detectCompletedAtNs: Long,
         height: Int,
         width: Int
     ) {
@@ -239,4 +242,3 @@ class MainActivity : AbcvlibActivity(), SerialReadyListener, BatteryDataSubscrib
         }
     }
 }
-

--- a/apps/handsOnApp/src/main/java/jp/oist/abcvlib/handsOnApp/MainActivity.kt
+++ b/apps/handsOnApp/src/main/java/jp/oist/abcvlib/handsOnApp/MainActivity.kt
@@ -133,6 +133,9 @@ class MainActivity : AbcvlibActivity(), BatteryDataSubscriber, SerialReadyListen
         mpImage: MPImage,
         results: MutableList<Detection>,
         inferenceTime: Long,
+        frameCapturedAtNs: Long,
+        detectStartedAtNs: Long,
+        detectCompletedAtNs: Long,
         height: Int,
         width: Int
     ) {

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/phone/ObjectDetectorData.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/phone/ObjectDetectorData.kt
@@ -3,7 +3,9 @@ package jp.oist.abcvlib.core.inputs.phone
 import android.content.Context
 import android.graphics.Bitmap
 import android.os.SystemClock
+import android.util.Size
 import androidx.camera.core.ImageAnalysis
+import android.view.Surface
 import androidx.camera.view.PreviewView
 import androidx.lifecycle.LifecycleOwner
 import com.google.mediapipe.framework.image.BitmapImageBuilder
@@ -15,6 +17,7 @@ import com.google.mediapipe.tasks.vision.objectdetector.ObjectDetector
 import jp.oist.abcvlib.core.inputs.PublisherManager
 import jp.oist.abcvlib.util.Logger
 import java.io.IOException
+import java.util.ArrayDeque
 import java.util.concurrent.ExecutorService
 
 /*
@@ -36,6 +39,15 @@ class ObjectDetectorData(
     imageExecutor
 ), ImageAnalysis.Analyzer {
 
+    override fun setDefaultImageAnalysis() {
+        imageAnalysis = ImageAnalysis.Builder()
+            .setTargetResolution(Size(640, 480))
+            .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+            .setImageQueueDepth(20)
+            .setTargetRotation(Surface.ROTATION_0)
+            .build()
+    }
+
     enum class delegates {
         DELEGATE_CPU,
         DELEGATE_GPU,
@@ -46,6 +58,9 @@ class ObjectDetectorData(
     private val threshold = 0.5f
     private val maxResults = 3
     private val numThreads = 2
+    private val inferenceTimesMs = ArrayDeque<Long>()
+    private val loopTimesMs = ArrayDeque<Long>()
+    private var lastDetectCompletedAtMs = 0L
 
     init {
         setupObjectDetector(currentDelegate, modelPath)
@@ -143,6 +158,7 @@ class ObjectDetectorData(
     ) {
         // Inference time is the difference between the system time at the start and finish of the
         // process
+        val detectStartedAtNs = SystemClock.elapsedRealtimeNanos()
         var inferenceTime = SystemClock.uptimeMillis()
 
         // Preprocess the image and convert it into a TensorImage for detection.
@@ -150,10 +166,33 @@ class ObjectDetectorData(
 
         val imageProcessingOptions = ImageProcessingOptions.builder()
             .setRotationDegrees(rotation)
-            .build() //todo check if this rotation is correct
+            .build()
 
         val results = objectDetector.detect(mpImage, imageProcessingOptions)
         inferenceTime = SystemClock.uptimeMillis() - inferenceTime
+        val detectCompletedAtNs = SystemClock.elapsedRealtimeNanos()
+        val detectCompletedAtMs = SystemClock.uptimeMillis()
+        val loopTime = if (lastDetectCompletedAtMs == 0L) {
+            0L
+        } else {
+            detectCompletedAtMs - lastDetectCompletedAtMs
+        }
+        lastDetectCompletedAtMs = detectCompletedAtMs
+
+        addRollingSample(inferenceTimesMs, inferenceTime)
+        if (loopTime > 0L) {
+            addRollingSample(loopTimesMs, loopTime)
+        }
+
+        Logger.v(
+            TAG,
+            "detect rotation=$rotation image=${width}x${height} " +
+                "detections=${results.detections().size} " +
+                "inferenceMs=$inferenceTime " +
+                "avgInferenceMs10=${averageMs(inferenceTimesMs)} " +
+                "loopMs=$loopTime " +
+                "avgLoopMs10=${averageMs(loopTimesMs)}"
+        )
 
         for (subscriber in subscribers) {
             subscriber.onObjectsDetected(
@@ -161,9 +200,26 @@ class ObjectDetectorData(
                 mpImage,
                 results.detections(),
                 inferenceTime,
+                timestamp,
+                detectStartedAtNs,
+                detectCompletedAtNs,
                 height,
                 width
             )
         }
+    }
+
+    private fun addRollingSample(samples: ArrayDeque<Long>, value: Long) {
+        samples.addLast(value)
+        while (samples.size > 10) {
+            samples.removeFirst()
+        }
+    }
+
+    private fun averageMs(samples: ArrayDeque<Long>): Long {
+        if (samples.isEmpty()) {
+            return 0L
+        }
+        return samples.sum() / samples.size
     }
 }

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/phone/ObjectDetectorDataSubscriber.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/phone/ObjectDetectorDataSubscriber.kt
@@ -11,6 +11,9 @@ interface ObjectDetectorDataSubscriber : Subscriber {
         mpImage: MPImage,
         results: MutableList<Detection>,
         inferenceTime: Long,
+        frameCapturedAtNs: Long,
+        detectStartedAtNs: Long,
+        detectCompletedAtNs: Long,
         height: Int,
         width: Int
     )

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/outputs/Outputs.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/outputs/Outputs.kt
@@ -2,6 +2,7 @@ package jp.oist.abcvlib.core.outputs
 
 import ioio.lib.api.exception.ConnectionLostException
 import jp.oist.abcvlib.core.Switches
+import jp.oist.abcvlib.util.ControlLatencyTrace
 import jp.oist.abcvlib.util.Logger
 import jp.oist.abcvlib.util.ProcessPriorityThreadFactory
 import jp.oist.abcvlib.util.ScheduledExecutorServiceWithException
@@ -118,6 +119,12 @@ class Outputs(
             Logger.w("Outputs", "New right wheel output $newRight is greater than 1. Clamping.")
             newRight = 1.0f
         }
+
+        ControlLatencyTrace.requestedLeft = left
+        ControlLatencyTrace.requestedRight = right
+        ControlLatencyTrace.sentLeft = newLeft
+        ControlLatencyTrace.sentRight = newRight
+        ControlLatencyTrace.outputsDtMs = dt
 
         serialCommManager.setMotorLevels(newLeft, newRight, leftBrake, rightBrake)
         lastLeft = newLeft

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/ControlLatencyTrace.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/ControlLatencyTrace.kt
@@ -1,0 +1,21 @@
+package jp.oist.abcvlib.util
+
+object ControlLatencyTrace {
+    @Volatile
+    var requestedLeft: Float = 0f
+
+    @Volatile
+    var requestedRight: Float = 0f
+
+    @Volatile
+    var sentLeft: Float = 0f
+
+    @Volatile
+    var sentRight: Float = 0f
+
+    @Volatile
+    var outputsDtMs: Long = 0L
+
+    @Volatile
+    var queueToSendMs: Long = 0L
+}

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/SerialCommManager.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/SerialCommManager.kt
@@ -1,5 +1,6 @@
 package jp.oist.abcvlib.util
 
+import android.os.SystemClock
 import com.hoho.android.usbserial.driver.SerialTimeoutException
 import jp.oist.abcvlib.core.inputs.microcontroller.BatteryData
 import jp.oist.abcvlib.core.inputs.microcontroller.WheelData
@@ -27,6 +28,7 @@ class SerialCommManager @JvmOverloads constructor(
     private val rp2040State: RP2040State?
 
     private var command: ByteArray? = null
+    private var queuedMotorLevelsAtMs: Long = 0L
     private val commandLock = Object()
     private val lifecycleLock = Any()
     private var runContext: RunContext? = null
@@ -77,6 +79,10 @@ class SerialCommManager @JvmOverloads constructor(
                 break
             }
 
+            if (queuedMotorLevelsAtMs > 0L) {
+                ControlLatencyTrace.queueToSendMs = SystemClock.uptimeMillis() - queuedMotorLevelsAtMs
+                queuedMotorLevelsAtMs = 0L
+            }
             sendPacket(nextCommand)
             cnt++
             if (cnt == 100) {
@@ -351,6 +357,7 @@ class SerialCommManager @JvmOverloads constructor(
             }
             command =
                 generateSetMotorLevels(androidToRP2040Packet, left, right, leftBrake, rightBrake)
+            queuedMotorLevelsAtMs = SystemClock.uptimeMillis()
             commandLock.notify()
         }
     }


### PR DESCRIPTION
## Summary
- In scope: split the shared object-detection timing API updates and control-latency tracing out of the comprehensiveDemo scaffold work, including the required mechanical call-site updates in the existing demo apps.
- Out of scope: any `comprehensiveDemo` app/controller behavior or other app-specific demo logic.
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `main`
- This PR branch: `ObjectDetectionUpdates`
- [ ] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [ ] Milestone tag is set on this PR.
- Migration guide used:
  - `docs/migrations/comprehensiveDemo.md`

## Scope Declaration
- Exact slice/module in this PR:
  - `libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/phone/ObjectDetectorData.kt`
  - `libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/phone/ObjectDetectorDataSubscriber.kt`
  - `libs/abcvlib/src/main/java/jp/oist/abcvlib/core/outputs/Outputs.kt`
  - `libs/abcvlib/src/main/java/jp/oist/abcvlib/util/ControlLatencyTrace.kt`
  - `libs/abcvlib/src/main/java/jp/oist/abcvlib/util/SerialCommManager.kt`
  - `apps/basicCharger/src/main/java/jp/oist/abcvlib/basiccharger/MainActivity.kt`
  - `apps/basicSubscriber/src/main/java/jp/oist/abcvlib/basicsubscriber/MainActivity.kt`
  - `apps/handsOnApp/src/main/java/jp/oist/abcvlib/handsOnApp/MainActivity.kt`
- Related sibling PRs/issues (remaining slices), if any:
  - `comprehensiveDemo/app-scaffold`
  - `QRCodeUpdates`
