### PR TITLE
fix(ci): fall back when codex inline review lines are unresolved

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -480,14 +480,43 @@ jobs:
             }
 
             if (newReviewComments.length > 0) {
-              await github.rest.pulls.createReview({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pullNumber,
-                event: 'REQUEST_CHANGES',
-                body: summary,
-                comments: newReviewComments,
-              });
+              try {
+                await github.rest.pulls.createReview({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pullNumber,
+                  event: 'REQUEST_CHANGES',
+                  body: summary,
+                  comments: newReviewComments,
+                });
+              } catch (err) {
+                const message = err?.message || '';
+                const isUnresolvedLine = err?.status === 422 && message.includes('Line could not be resolved');
+                if (!isUnresolvedLine) {
+                  throw err;
+                }
+
+                core.warning(`Inline review comment could not be resolved. Falling back to body-only review: ${message}`);
+
+                const fallbackFindings = newReviewComments.map((c) => `- \`${c.path}:${c.line}\` ${c.body}`);
+                const fallbackBody = [
+                  summary,
+                  '',
+                  'Inline comment positions could not be resolved for one or more findings, so they are listed below instead:',
+                  '',
+                  '**Unresolved inline findings**',
+                  ...fallbackFindings,
+                ].join('\n');
+
+                await github.rest.pulls.createReview({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pullNumber,
+                  event: 'REQUEST_CHANGES',
+                  body: fallbackBody,
+                  comments: [],
+                });
+              }
               return;
             }
 


### PR DESCRIPTION
## Summary
- What is in scope for this PR?
  - Fix the `codex-review` workflow so unresolved inline review comment positions do not fail the workflow
  - Fall back to a body-only `REQUEST_CHANGES` review when GitHub cannot resolve a requested inline line position
- What is intentionally out of scope?
  - Changes to Codex review prompting or matcher logic
  - Changes to any app/library source files
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `main`
- This PR branch: `codexReviewFix`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [ ] Milestone tag is set on this PR.
- Migration guide used:
  - none (workflow-only fix against `main`)

## Scope Declaration
- Exact slice/module in this PR:
  - `.github/workflows/codex-review.yml`
- Related sibling PRs/issues (remaining slices), if any:
  - none
