### PR TITLE
Add edge-to-edge support

### DIFF
--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/AbcvlibActivity.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/AbcvlibActivity.kt
@@ -7,6 +7,9 @@ import android.view.WindowManager
 import android.widget.Button
 import androidx.annotation.WorkerThread
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.lifecycleScope
 import jp.oist.abcvlib.core.outputs.Outputs
 import jp.oist.abcvlib.util.Logger
@@ -51,9 +54,29 @@ abstract class AbcvlibActivity : AppCompatActivity(), SerialReadyListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         isCreated = true
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         usbInitialize()
         super.onCreate(savedInstanceState)
+
+        val contentView = findViewById<android.view.View>(android.R.id.content)
+        contentView?.let { view ->
+            val initialPaddingLeft = view.paddingLeft
+            val initialPaddingTop = view.paddingTop
+            val initialPaddingRight = view.paddingRight
+            val initialPaddingBottom = view.paddingBottom
+
+            ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+                val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+                v.setPadding(
+                    initialPaddingLeft + systemBars.left,
+                    initialPaddingTop + systemBars.top,
+                    initialPaddingRight + systemBars.right,
+                    initialPaddingBottom + systemBars.bottom
+                )
+                insets
+            }
+        }
     }
 
     private fun usbInitialize() {


### PR DESCRIPTION
## Summary
- What is in scope for this PR?
Android 15 made edge-to-edge display mode mandatory, Android 16 made it so it is no longer possible to opt out of using it. The problem is that this mode breaks the UI of every test activity. It is a problem since some parts of the UI get covered by app bar or system bars. This PR adds Edge-to-Edge support for newer Android phones without breaking UI for older ones.

- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `main`
- This PR branch: `maintenance/EdgeToEdge`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [x] Milestone tag is set on this PR.

## Scope Declaration
- Exact slice/module in this PR:
  - `libs/abcvlib/src/main/java/jp/oist/abcvlib/core/AbcvlibActivity.kt`
- Related sibling PRs/issues (remaining slices), if any:
  - #8 
