### PR TITLE
HandsOnApp rotate the image in non UI Thread

### DIFF
--- a/apps/handsOnApp/src/main/java/jp/oist/abcvlib/handsOnApp/MainActivity.kt
+++ b/apps/handsOnApp/src/main/java/jp/oist/abcvlib/handsOnApp/MainActivity.kt
@@ -19,10 +19,14 @@ import jp.oist.abcvlib.handsOnApp.databinding.ActivityMainBinding
 import jp.oist.abcvlib.util.SerialCommManager
 import jp.oist.abcvlib.util.SerialReadyListener
 import jp.oist.abcvlib.util.UsbSerial
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -39,6 +43,7 @@ class MainActivity : AbcvlibActivity(), BatteryDataSubscriber, SerialReadyListen
     private var countR = 0
     private var nLoopCalled = 0
     private var imageLabel = "Nothing"
+    private val isProcessing = AtomicBoolean(false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         binding = ActivityMainBinding.inflate(layoutInflater)
@@ -138,31 +143,41 @@ class MainActivity : AbcvlibActivity(), BatteryDataSubscriber, SerialReadyListen
         height: Int,
         width: Int
     ) {
-        try {
-            val matrix = Matrix()
-            matrix.postRotate(270f)
-            val rotatedBitmap = Bitmap.createBitmap(
-                bitmap,
-                0, 0,
-                bitmap.width,
-                bitmap.height,
-                matrix, true
-            )
-            val scaledBitmap = rotatedBitmap.scale(
-                rotatedBitmap.width * 4, rotatedBitmap.height * 4
-            )
-            debugInfo.image = scaledBitmap
-            val category = results[0].categories()[0]
-            imageLabel = category.categoryName()
-            debugInfo.text3 = String.format(
-                Locale.getDefault(),
-                "Label: %s (score: %.2f)",
-                imageLabel,
-                category.score()
-            )
-        } catch (e: IndexOutOfBoundsException) {
-            imageLabel = "Nothing"
-            debugInfo.text3 = "No object detected"
+        if (!isProcessing.compareAndSet(false, true)) return
+        lifecycleScope.launch(Dispatchers.Default) {
+            try {
+                val matrix = Matrix()
+                matrix.postRotate(270f)
+                val rotatedBitmap = Bitmap.createBitmap(
+                    bitmap,
+                    0, 0,
+                    bitmap.width,
+                    bitmap.height,
+                    matrix, true
+                )
+                val scaledBitmap = rotatedBitmap.scale(
+                    rotatedBitmap.width * 4, rotatedBitmap.height * 4
+                )
+
+                withContext(Dispatchers.Main) {
+                    debugInfo.image = scaledBitmap
+                    val category = results[0].categories()[0]
+                    imageLabel = category.categoryName()
+                    debugInfo.text3 = String.format(
+                        Locale.getDefault(),
+                        "Label: %s (score: %.2f)",
+                        imageLabel,
+                        category.score()
+                    )
+                }
+            } catch (e: IndexOutOfBoundsException) {
+                withContext(Dispatchers.Main) {
+                    imageLabel = "Nothing"
+                    debugInfo.text3 = "No object detected"
+                }
+            } finally {
+                isProcessing.set(false)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- What is in scope for this PR?
Image rotation is being done in UI thread, this blocks the thread. This PR delegates image rotation to a different coroutine scope, only delivering UI updates in the main thread

- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `main`
- This PR branch: `maintenance/ImageRotate`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [x] Milestone tag is set on this PR.

## Scope Declaration
- Exact slice/module in this PR:
  - `apps/handsOnApp/src/main/java/jp/oist/abcvlib/handsOnApp/MainActivity.kt`
- Related sibling PRs/issues (remaining slices), if any:
  - #105 
