### PR TITLE
Firmware benchmarking/parse firmware benchmarks

### DIFF
--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -19,11 +19,12 @@ To precisely isolate delays, the following high-resolution timestamps (`System.n
 | **T1** | Command Creation Start    | `SerialCommManager.setMotorLevels()`                 |
 | **T2** | Writer Loop Wake-up       | `SerialCommManager.android2PiWriter` (after `wait`)  |
 | **T3** | Transport Dispatch        | `UsbSerial.send(ByteArray)` (start)                  |
-| **T4** | Simulator Receipt         | `MockRP2040.processPacket()` (start)                 |
-| **T5** | Response Receipt at Phone | `UsbSerial.onNewData()` (start)                      |
-| **T6** | Packet Queue Entry        | `UsbSerial.onCompletePacketReceived()` (end)         |
-| **T7** | Manager Wake-up           | `SerialCommManager.receivePacket()` (after await)    |
-| **T8** | State Applied             | `SerialCommManager.parseStatus()` (after publishers) |
+| **T4** | Firmware Received Command | `Firmware getBlock` (detecting a command)            |
+| **T5** | Firmware Processing Done  | `Firmware handle_packet` (after processing)          |
+| **T6** | Response Receipt at Phone | `UsbSerial.onNewData()` (start)                      |
+| **T7** | Packet Queue Entry        | `UsbSerial.onCompletePacketReceived()` (end)         |
+| **T8** | Manager Wake-up           | `SerialCommManager.receivePacket()` (after await)    |
+| **T9** | State Applied             | `SerialCommManager.parseStatus()` (after publishers) |
 
 ## 2. Calculated Metrics
 
@@ -33,12 +34,13 @@ The following metrics are derived from the timestamps above to measure specific 
 |:-------------------------------|:------------|:------------------------------------------------------------------------------|
 | **M1: Outbound Queueing**      | $T2 - T1$   | Delay between command creation and the background thread picking it up.       |
 | **M2: Handling/Serialization** | $T3 - T2$   | Time from thread wake-up until bytes are sent (includes `command.toBytes()`). |
-| **M3: Transport Out**          | $T4 - T3$   | Latency from the phone to the robot (includes `VirtualRobotPort` dispatch).    |
-| **M4: Robot + Transit In**     | $T5 - T4$   | Simulator processing time (5ms sleep) + Response transit back to phone.        |
-| **M5: Buffer Processing**      | $T6 - T5$   | Time spent inside `PacketBuffer` parsing the response.                        |
-| **M6: Wake-up Lag**            | $T7 - T6$   | Delay between the packet being queued and the manager thread waking up.       |
-| **M7: App logic**              | $T8 - T7$   | Time taken to update internal state models and notify UI publishers.          |
-| **Total RTT**                  | $T8 - T1$   | The full round-trip latency as experienced by the application.                |
+| **M3: Transport Out**          | $T4 - T3$   | Latency from the phone to the robot (includes `VirtualRobotPort` dispatch).   |
+| **M4: Firmware Processing**    | $T5 - T4$   | Time spent inside firmware after the firmware receives the packet.            |
+| **M5: Response Transit In**    | $T6 - T5$   | Time from firmware completion until the phone receives the response bytes.    |
+| **M6: Buffer Processing**      | $T7 - T6$   | Time spent inside `PacketBuffer` parsing the response.                        |
+| **M7: Wake-up Lag**            | $T8 - T7$   | Delay between the packet being queued and the manager thread waking up.       |
+| **M8: App logic**              | $T9 - T8$   | Time taken to update internal state models and notify UI publishers.          |
+| **Total RTT**                  | $T9 - T1$   | The full round-trip latency as experienced by the application.                |
 
 ## 3. Methodology
 

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -14,17 +14,17 @@ This file remains the stable methodology reference and keeps older result tables
 
 To precisely isolate delays, the following high-resolution timestamps (`System.nanoTime()`) are captured during a single command-response cycle:
 
-| ID     | Junction Point            | Location                                             |
-|:-------|:--------------------------|:-----------------------------------------------------|
-| **T1** | Command Creation Start    | `SerialCommManager.setMotorLevels()`                 |
-| **T2** | Writer Loop Wake-up       | `SerialCommManager.android2PiWriter` (after `wait`)  |
-| **T3** | Transport Dispatch        | `UsbSerial.send(ByteArray)` (start)                  |
-| **T4** | Firmware Received Command | `Firmware getBlock` (detecting a command)            |
-| **T5** | Firmware Processing Done  | `Firmware handle_packet` (after processing)          |
-| **T6** | Response Receipt at Phone | `UsbSerial.onNewData()` (start)                      |
-| **T7** | Packet Queue Entry        | `UsbSerial.onCompletePacketReceived()` (end)         |
-| **T8** | Manager Wake-up           | `SerialCommManager.receivePacket()` (after await)    |
-| **T9** | State Applied             | `SerialCommManager.parseStatus()` (after publishers) |
+| ID     | Junction Point            | Location                                                                                    |
+|:-------|:--------------------------|:--------------------------------------------------------------------------------------------|
+| **T1** | Command Creation Start    | `SerialCommManager.setMotorLevels()`                                                        |
+| **T2** | Writer Loop Wake-up       | `SerialCommManager.android2PiWriter` (after `wait`)                                         |
+| **T3** | Transport Dispatch        | `UsbSerial.send(ByteArray)` (start)                                                         |
+| **T4** | Firmware Received Command | `Firmware getBlock` (detecting a command) / `MockRP2040.processPacket` (start)              |
+| **T5** | Firmware Processing Done  | `Firmware handle_packet` (after processing) / `MockRP2040.processPacket` (after processing) |
+| **T6** | Response Receipt at Phone | `PacketBuffer.consume` (after reading the packet type)                                      |
+| **T7** | Packet Queue Entry        | `UsbSerial.onCompletePacketReceived()` (end)                                                |
+| **T8** | Manager Wake-up           | `SerialCommManager.receivePacket()` (after await)                                           |
+| **T9** | State Applied             | `SerialCommManager.parseStatus()` (after publishers)                                        |
 
 ## 2. Calculated Metrics
 
@@ -112,3 +112,18 @@ Success Rate: 100.00% (10000/10000)
 | M6: Wake-up Lag            | 0.771     | 0.115    | 4.167    | 1.254    |
 | M7: App Logic              | 1.905     | 0.211    | 11.506   | 2.884    |
 | Total RTT                  | 11.196    | 6.248    | 30.403   | 13.139   |
+
+
+#### New packet parsing implementation
+
+| Metric                     | Mean (ms) | Min (ms) | Max (ms) | P95 (ms) |
+|:---------------------------|:----------|:---------|:---------|:---------|
+| M1: Outbound Queueing      | 0.436     | 0.045    | 2.259    | 0.959    |
+| M2: Handling/Serialization | 0.143     | 0.019    | 1.563    | 0.281    |
+| M3: Transport Out          | 1.070     | 0.219    | 4.029    | 1.677    |
+| M4: Firmware Processing    | 5.367     | 5.103    | 9.883    | 5.668    |
+| M5: Response Transit in    | 1.070     | 0.219    | 4.029    | 1.677    |
+| M6: Buffer Processing      | 1.048     | 0.187    | 3.827    | 1.716    |
+| M7: Wake-up Lag            | 0.838     | 0.097    | 4.946    | 1.673    |
+| M8: App Logic              | 1.714     | 0.195    | 5.855    | 3.092    |
+| Total RTT                  | 11.686    | 6.311    | 18.619   | 15.051   |

--- a/docs/benchmarks/latency/history.csv
+++ b/docs/benchmarks/latency/history.csv
@@ -1,5 +1,3 @@
 commit,generated_utc,runner,uses_real_firmware,firmware,measured_iterations,success_rate,mean_rtt_ms,p95_rtt_ms,max_rtt_ms
-4e96e9e0,2026-07-02T12:23:57.5957900Z,Samsung Galaxy A35,FALSE,,10000,100,11.196,13.139,30.403
-3639c37a0ae8f8960bb493a226ff1c06e801a1f4,2026-07-02T16:39:20.082533Z,samsung SM-A356E (physical device),FALSE,MockRP2040 simulator with 5 ms processing delay,1000,100.00,6.760,8.058,14.482
-3639c37a0ae8f8960bb493a226ff1c06e801a1f4,2026-07-02T16:41:56.004538Z,samsung SM-A356E (physical device),FALSE,MockRP2040 simulator with 5 ms processing delay,1000,100.00,8.634,11.452,16.350
-858fe6da7833e028a5f519a5b0417f2d42996426,2026-07-02T16:45:33.510188Z,samsung SM-A356E (physical device),FALSE,MockRP2040 simulator with 5 ms processing delay,1000,100.00,8.508,11.359,19.376
+4e96e9e0,2026-07-02T12:23:57.5957900Z,Samsung Galaxy A35,FALSE,,10000,100,11.196,13.139,30.40396
+96acaacc180fbef8b067abf98f7a3b1741cd9617,2026-07-22T09:08:23.759522Z,samsung SM-A356E (physical device),FALSE,MockRP2040 simulator with 5 ms processing delay,1000,100.00,8.376,12.726,19.596

--- a/docs/benchmarks/latency/history.csv
+++ b/docs/benchmarks/latency/history.csv
@@ -1,3 +1,3 @@
 commit,generated_utc,runner,uses_real_firmware,firmware,measured_iterations,success_rate,mean_rtt_ms,p95_rtt_ms,max_rtt_ms
 4e96e9e0,2026-07-02T12:23:57.5957900Z,Samsung Galaxy A35,FALSE,,10000,100,11.196,13.139,30.40396
-96acaacc180fbef8b067abf98f7a3b1741cd9617,2026-07-22T09:08:23.759522Z,samsung SM-A356E (physical device),FALSE,MockRP2040 simulator with 5 ms processing delay,1000,100.00,8.376,12.726,19.596
+108b21174c15afc69cf1bc9bbfa372f955193c89,2026-07-22T09:14:11.042918Z,samsung SM-A356E (physical device),FALSE,MockRP2040 simulator with 5 ms processing delay,1000,100.00,8.076,12.638,16.415

--- a/docs/benchmarks/latency/latest.md
+++ b/docs/benchmarks/latency/latest.md
@@ -1,6 +1,6 @@
 ### Benchmark Results (1000 iterations)
 
-- Generated at (UTC): 2026-07-02T16:45:33.510188Z
+- Generated at (UTC): 2026-07-22T09:08:23.759522Z
 - Runner: samsung SM-A356E (physical device)
 - Android: 16 (API 36)
 - Device: brand=samsung, device=a35x, product=a35xjvxx
@@ -8,7 +8,7 @@
 - Transport: VirtualRobotPort
 - Firmware: MockRP2040 simulator with 5 ms processing delay
 - Protocol: Existing RP2040 serial request/response protocol
-- Git commit: 858fe6da7833e028a5f519a5b0417f2d42996426 (clean)
+- Git commit: 96acaacc180fbef8b067abf98f7a3b1741cd9617 (dirty)
 - Warm-up iterations: 100
 - Measured iterations: 1000
 
@@ -16,11 +16,12 @@ Success Rate: 100.00% (1000/1000)
 
 | Metric                             | Mean (ms) | Min (ms) | Max (ms) | P95 (ms) |
 |:-----------------------------------|:----------|:---------|:---------|:---------|
-| M1: Outbound Queueing              | 0.287     | 0.044    | 5.633    | 0.977    |
-| M2: Handling/Serialization         | 0.061     | 0.015    | 1.996    | 0.123    |
-| M3: Android Write Blocking         | 0.616     | 0.163    | 4.779    | 1.208    |
-| M4: Response Wait After Write      | 5.816     | 4.910    | 11.959   | 6.935    |
-| M5: Buffer Processing              | 0.521     | 0.143    | 4.318    | 0.966    |
-| M6: Wake-up Lag                    | 0.519     | 0.095    | 3.717    | 1.150    |
-| M7: App Logic                      | 0.688     | 0.186    | 3.888    | 1.322    |
-| Total RTT                          | 8.508     | 6.018    | 19.376   | 11.359   |
+| M1: Outbound Queueing              | 0.236     | 0.043    | 6.257    | 0.779    |
+| M2: Handling/Serialization         | 0.071     | 0.016    | 0.596    | 0.184    |
+| M3: Transport Out                  | 0.516     | 0.170    | 2.888    | 1.174    |
+| M4: Firmware Processing            | 5.249     | 5.099    | 7.642    | 5.595    |
+| M5: Response Transit in            | 0.516     | 0.170    | 2.888    | 1.174    |
+| M6: Buffer Processing              | 0.563     | 0.181    | 3.757    | 1.202    |
+| M7: Wake-up Lag                    | 0.458     | 0.096    | 5.575    | 1.263    |
+| M8: App Logic                      | 0.767     | 0.177    | 4.965    | 2.201    |
+| Total RTT                          | 8.376     | 6.180    | 19.596   | 12.726   |

--- a/docs/benchmarks/latency/latest.md
+++ b/docs/benchmarks/latency/latest.md
@@ -1,6 +1,6 @@
 ### Benchmark Results (1000 iterations)
 
-- Generated at (UTC): 2026-07-22T09:08:23.759522Z
+- Generated at (UTC): 2026-07-22T09:14:11.042918Z
 - Runner: samsung SM-A356E (physical device)
 - Android: 16 (API 36)
 - Device: brand=samsung, device=a35x, product=a35xjvxx
@@ -8,7 +8,7 @@
 - Transport: VirtualRobotPort
 - Firmware: MockRP2040 simulator with 5 ms processing delay
 - Protocol: Existing RP2040 serial request/response protocol
-- Git commit: 96acaacc180fbef8b067abf98f7a3b1741cd9617 (dirty)
+- Git commit: 108b21174c15afc69cf1bc9bbfa372f955193c89 (dirty)
 - Warm-up iterations: 100
 - Measured iterations: 1000
 
@@ -16,12 +16,12 @@ Success Rate: 100.00% (1000/1000)
 
 | Metric                             | Mean (ms) | Min (ms) | Max (ms) | P95 (ms) |
 |:-----------------------------------|:----------|:---------|:---------|:---------|
-| M1: Outbound Queueing              | 0.236     | 0.043    | 6.257    | 0.779    |
-| M2: Handling/Serialization         | 0.071     | 0.016    | 0.596    | 0.184    |
-| M3: Transport Out                  | 0.516     | 0.170    | 2.888    | 1.174    |
-| M4: Firmware Processing            | 5.249     | 5.099    | 7.642    | 5.595    |
-| M5: Response Transit in            | 0.516     | 0.170    | 2.888    | 1.174    |
-| M6: Buffer Processing              | 0.563     | 0.181    | 3.757    | 1.202    |
-| M7: Wake-up Lag                    | 0.458     | 0.096    | 5.575    | 1.263    |
-| M8: App Logic                      | 0.767     | 0.177    | 4.965    | 2.201    |
-| Total RTT                          | 8.376     | 6.180    | 19.596   | 12.726   |
+| M1: Outbound Queueing              | 0.185     | 0.037    | 3.484    | 0.520    |
+| M2: Handling/Serialization         | 0.069     | 0.016    | 1.550    | 0.179    |
+| M3: Transport Out                  | 0.487     | 0.158    | 2.005    | 1.193    |
+| M4: Firmware Processing            | 5.221     | 5.090    | 8.178    | 5.469    |
+| M5: Response Transit in            | 0.487     | 0.158    | 2.005    | 1.193    |
+| M6: Buffer Processing              | 0.513     | 0.171    | 3.052    | 1.126    |
+| M7: Wake-up Lag                    | 0.390     | 0.100    | 2.170    | 1.058    |
+| M8: App Logic                      | 0.723     | 0.212    | 4.748    | 2.259    |
+| Total RTT                          | 8.076     | 6.099    | 16.415   | 12.638   |

--- a/docs/benchmarks/latency/plot.svg
+++ b/docs/benchmarks/latency/plot.svg
@@ -31,26 +31,18 @@
 <text x="78" y="116.00" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="end">14</text>
 
 
-  <polyline fill="none" stroke="#38bdf8" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" points="90.00,207.74 443.33,359.19 796.67,295.21 1150.00,299.51"/>
-  <polyline fill="none" stroke="#f97316" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" points="90.00,141.40 443.33,314.88 796.67,199.00 1150.00,202.17"/>
+  <polyline fill="none" stroke="#38bdf8" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" points="90.00,207.74 1150.00,304.02"/>
+  <polyline fill="none" stroke="#f97316" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" points="90.00,141.40 1150.00,155.50"/>
   <circle cx="90.00" cy="207.74" r="5" fill="#38bdf8"/>
-<circle cx="443.33" cy="359.19" r="5" fill="#38bdf8"/>
-<circle cx="796.67" cy="295.21" r="5" fill="#38bdf8"/>
-<circle cx="1150.00" cy="299.51" r="5" fill="#38bdf8"/>
+<circle cx="1150.00" cy="304.02" r="5" fill="#38bdf8"/>
   <circle cx="90.00" cy="141.40" r="5" fill="#f97316"/>
-<circle cx="443.33" cy="314.88" r="5" fill="#f97316"/>
-<circle cx="796.67" cy="199.00" r="5" fill="#f97316"/>
-<circle cx="1150.00" cy="202.17" r="5" fill="#f97316"/>
+<circle cx="1150.00" cy="155.50" r="5" fill="#f97316"/>
 
   <text x="600" y="662" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle">Commits</text>
   <text x="46" y="351" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle" transform="rotate(-90 46 351)">RTT ms</text>
   <text x="90.00" y="616" fill="#e2e8f0" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle">4e96e9e0</text>
 <text x="90.00" y="636" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="11" text-anchor="middle">2026-07-02</text>
-<text x="443.33" y="616" fill="#e2e8f0" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle">3639c37a</text>
-<text x="443.33" y="636" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="11" text-anchor="middle">2026-07-02</text>
-<text x="796.67" y="616" fill="#e2e8f0" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle">3639c37a</text>
-<text x="796.67" y="636" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="11" text-anchor="middle">2026-07-02</text>
-<text x="1150.00" y="616" fill="#e2e8f0" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle">858fe6da</text>
-<text x="1150.00" y="636" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="11" text-anchor="middle">2026-07-02</text>
+<text x="1150.00" y="616" fill="#e2e8f0" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle">96acaacc</text>
+<text x="1150.00" y="636" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="11" text-anchor="middle">2026-07-22</text>
 
 </svg>

--- a/docs/benchmarks/latency/plot.svg
+++ b/docs/benchmarks/latency/plot.svg
@@ -31,18 +31,18 @@
 <text x="78" y="116.00" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="end">14</text>
 
 
-  <polyline fill="none" stroke="#38bdf8" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" points="90.00,207.74 1150.00,304.02"/>
-  <polyline fill="none" stroke="#f97316" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" points="90.00,141.40 1150.00,155.50"/>
+  <polyline fill="none" stroke="#38bdf8" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" points="90.00,207.74 1150.00,314.26"/>
+  <polyline fill="none" stroke="#f97316" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" points="90.00,141.40 1150.00,158.50"/>
   <circle cx="90.00" cy="207.74" r="5" fill="#38bdf8"/>
-<circle cx="1150.00" cy="304.02" r="5" fill="#38bdf8"/>
+<circle cx="1150.00" cy="314.26" r="5" fill="#38bdf8"/>
   <circle cx="90.00" cy="141.40" r="5" fill="#f97316"/>
-<circle cx="1150.00" cy="155.50" r="5" fill="#f97316"/>
+<circle cx="1150.00" cy="158.50" r="5" fill="#f97316"/>
 
   <text x="600" y="662" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle">Commits</text>
   <text x="46" y="351" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle" transform="rotate(-90 46 351)">RTT ms</text>
   <text x="90.00" y="616" fill="#e2e8f0" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle">4e96e9e0</text>
 <text x="90.00" y="636" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="11" text-anchor="middle">2026-07-02</text>
-<text x="1150.00" y="616" fill="#e2e8f0" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle">96acaacc</text>
+<text x="1150.00" y="616" fill="#e2e8f0" font-family="Arial, Helvetica, sans-serif" font-size="12" text-anchor="middle">108b2117</text>
 <text x="1150.00" y="636" fill="#94a3b8" font-family="Arial, Helvetica, sans-serif" font-size="11" text-anchor="middle">2026-07-22</text>
 
 </svg>

--- a/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/BenchmarkClock.kt
+++ b/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/BenchmarkClock.kt
@@ -19,7 +19,7 @@ object BenchmarkClock {
 
     fun startIteration(iteration: Int) {
         if (!enabled) return
-        iterations[iteration] = LongArray(8) // T1 to T8
+        iterations[iteration] = LongArray(9) // T1 to T9
         successStates[iteration] = false
     }
 
@@ -32,12 +32,12 @@ object BenchmarkClock {
     fun mark(iteration: Int, junction: Int) {
         if (!enabled || iteration == -1) return
         val timestamps = iterations[iteration] ?: return
-        if (junction !in 1..8) return
+        if (junction !in 1..9) return
 
         val index = junction - 1
 
         // Ensure that junctions are marked in order for a single command-response cycle.
-        // This prevents a late T7 from a previous iteration from being recorded in a new one,
+        // This prevents a late T8 from a previous iteration from being recorded in a new one,
         // and ensures we only track the first valid sequence.
         if (junction > 1 && timestamps[index - 1] == 0L) return
 

--- a/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/BenchmarkClock.kt
+++ b/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/BenchmarkClock.kt
@@ -29,22 +29,24 @@ object BenchmarkClock {
         successStates[iteration] = true
     }
 
-    fun mark(iteration: Int, junction: Int) {
-        if (!enabled || iteration == -1) return
-        val timestamps = iterations[iteration] ?: return
-        if (junction !in 1..9) return
+    fun mark(iteration: Int, junction: Int): Long? {
+        return markAt(iteration, junction, System.nanoTime())
+    }
+
+    fun markAt(iteration: Int, junction: Int, timestampNs: Long): Long? {
+        if (!enabled || iteration == -1) return null
+        val timestamps = iterations[iteration] ?: return null
+        if (junction !in 1..9) return null
 
         val index = junction - 1
 
-        // Ensure that junctions are marked in order for a single command-response cycle.
-        // This prevents a late T8 from a previous iteration from being recorded in a new one,
-        // and ensures we only track the first valid sequence.
-        if (junction > 1 && timestamps[index - 1] == 0L) return
-
         // Prevent overwriting a junction that was already marked for this iteration.
         if (timestamps[index] == 0L) {
-            timestamps[index] = System.nanoTime()
+            timestamps[index] = timestampNs
+            return timestampNs
         }
+
+        return timestamps[index]
     }
 
     fun getResults(): Map<Int, LongArray> = iterations.toMap()

--- a/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyBenchmark.kt
+++ b/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyBenchmark.kt
@@ -79,6 +79,7 @@ class LatencyBenchmark {
             )
         } else {
             simulator = MockRP2040()
+            simulator.benchmarkIterationProvider = { currentIteration.get() }
             val virtualPort = VirtualRobotPort(simulator)
             usbSerial = LatencyMeasuringUsbSerial(
                 context = context,
@@ -193,11 +194,12 @@ class LatencyBenchmark {
         val metricNames = listOf(
             "M1: Outbound Queueing",
             "M2: Handling/Serialization",
-            "M3: Android Write Blocking",
-            "M4: Response Wait After Write",
-            "M5: Buffer Processing",
-            "M6: Wake-up Lag",
-            "M7: App Logic",
+            "M3: Transport Out",
+            "M4: Firmware Processing",
+            "M5: Response Transit in",
+            "M6: Buffer Processing",
+            "M7: Wake-up Lag",
+            "M8: App Logic",
             "Total RTT"
         )
 
@@ -222,7 +224,8 @@ class LatencyBenchmark {
             val m5 = (ts[5] - ts[4]) / 1_000_000.0
             val m6 = (ts[6] - ts[5]) / 1_000_000.0
             val m7 = (ts[7] - ts[6]) / 1_000_000.0
-            val total = (ts[7] - ts[0]) / 1_000_000.0
+            val m8 = (ts[8] - ts[7]) / 1_000_000.0
+            val total = (ts[8] - ts[0]) / 1_000_000.0
 
             metrics[metricNames[0]]!!.add(m1)
             metrics[metricNames[1]]!!.add(m2)
@@ -231,6 +234,7 @@ class LatencyBenchmark {
             metrics[metricNames[4]]!!.add(m5)
             metrics[metricNames[5]]!!.add(m6)
             metrics[metricNames[6]]!!.add(m7)
+            metrics[metricNames[7]]!!.add(m8)
             metrics["Total RTT"]!!.add(total)
         }
 

--- a/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyBenchmark.kt
+++ b/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyBenchmark.kt
@@ -11,14 +11,10 @@ import jp.oist.abcvlib.core.BuildConfig
 import jp.oist.abcvlib.core.inputs.PublisherManager
 import jp.oist.abcvlib.core.inputs.microcontroller.BatteryData
 import jp.oist.abcvlib.core.inputs.microcontroller.WheelData
-import jp.oist.abcvlib.util.latency.BenchmarkClock
-import jp.oist.abcvlib.util.SerialCommManager
 import jp.oist.abcvlib.util.SerialReadyListener
 import jp.oist.abcvlib.util.UsbSerial
 import jp.oist.abcvlib.util.VirtualRobotPort
 import jp.oist.abcvlib.util.rp2040.MockRP2040
-import jp.oist.abcvlib.util.rp2040.RP2040OutgoingCommand
-import junit.framework.TestCase.assertEquals
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -31,13 +27,12 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.math.absoluteValue
 
 @RunWith(AndroidJUnit4::class)
 class LatencyBenchmark {
 
     private lateinit var simulator: MockRP2040
-    private lateinit var usbSerial: UsbSerial
+    private lateinit var usbSerial: LatencyMeasuringUsbSerial
     private lateinit var commManager: LatencyMeasuringSerialCommManager
     private lateinit var publisherManager: PublisherManager
     private lateinit var wheelData: WheelData
@@ -145,6 +140,7 @@ class LatencyBenchmark {
                 commManager.setMotorLevelsForBenchmark(i, speed, speed, false, false)
 
                 val success = iterationLatch.await(BENCHMARK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                usbSerial.assertTelemetryAvailable()
                 Assert.assertTrue(
                     "Iteration $i timed out after ${BENCHMARK_TIMEOUT_MS}ms; " +
                             "aborting benchmark to avoid attributing late responses to later iterations.",

--- a/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyMeasuringSerialCommManager.kt
+++ b/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyMeasuringSerialCommManager.kt
@@ -36,8 +36,8 @@ class LatencyMeasuringSerialCommManager @JvmOverloads constructor(
     override fun receivePacket() {
         val receivedStatus = usbSerial.awaitPacketReceived(10000)
 
-        // T7: Manager Wake-up
-        BenchmarkClock.mark(currentIteration.get(), 7)
+        // T8: Manager Wake-up
+        BenchmarkClock.mark(currentIteration.get(), 8)
 
         if (receivedStatus == 1) {
             //Note this is actually calling the functions like parseLog, parseStatus, etc.
@@ -62,9 +62,9 @@ class LatencyMeasuringSerialCommManager @JvmOverloads constructor(
         val result = super.parseStatus(command)
 
         if (result && command is RP2040IncomingCommand.SetMotorLevels) {
-            // T8: State Applied
+            // T9: State Applied
             val iteration = currentIteration.get()
-            BenchmarkClock.mark(iteration, 8)
+            BenchmarkClock.mark(iteration, 9)
             BenchmarkClock.recordSuccess(iteration)
             currentIteration.compareAndSet(iteration, NO_ITERATION)
             onResultProcessed?.invoke()

--- a/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyMeasuringSerialCommManager.kt
+++ b/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyMeasuringSerialCommManager.kt
@@ -3,19 +3,18 @@ package jp.oist.abcvlib.util.latency
 import jp.oist.abcvlib.core.inputs.microcontroller.BatteryData
 import jp.oist.abcvlib.core.inputs.microcontroller.WheelData
 import jp.oist.abcvlib.util.SerialCommManager
-import jp.oist.abcvlib.util.UsbSerial
 import jp.oist.abcvlib.util.rp2040.RP2040IncomingCommand
 import jp.oist.abcvlib.util.rp2040.RP2040OutgoingCommand
 import jp.oist.abcvlib.util.rp2040.StatusCommand
 import java.util.concurrent.atomic.AtomicInteger
 
-class LatencyMeasuringSerialCommManager @JvmOverloads constructor(
-    usbSerial: UsbSerial,
+internal class LatencyMeasuringSerialCommManager @JvmOverloads constructor(
+    private val benchmarkUsbSerial: LatencyMeasuringUsbSerial,
     private val currentIteration: AtomicInteger,
     batteryData: BatteryData? = null,
     wheelData: WheelData? = null
 ) : SerialCommManager(
-    usbSerial = usbSerial,
+    usbSerial = benchmarkUsbSerial,
     batteryData = batteryData,
     wheelData = wheelData
 ) {
@@ -28,13 +27,19 @@ class LatencyMeasuringSerialCommManager @JvmOverloads constructor(
     override fun sendCommand(command: RP2040OutgoingCommand): Int {
         if (command is RP2040OutgoingCommand.SetMotorLevels) {
             BenchmarkClock.mark(currentIteration.get(), 2)
+            benchmarkUsbSerial.setBenchmarkTrafficActive(true)
+            try {
+                return super.sendCommand(command)
+            } finally {
+                benchmarkUsbSerial.setBenchmarkTrafficActive(false)
+            }
         }
 
         return super.sendCommand(command)
     }
 
     override fun receivePacket() {
-        val receivedStatus = usbSerial.awaitPacketReceived(10000)
+        val receivedStatus = benchmarkUsbSerial.awaitPacketReceived(10000)
 
         // T8: Manager Wake-up
         BenchmarkClock.mark(currentIteration.get(), 8)

--- a/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyMeasuringUsbSerial.kt
+++ b/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyMeasuringUsbSerial.kt
@@ -23,8 +23,8 @@ internal class LatencyMeasuringUsbSerial @Throws(IOException::class) constructor
 ) {
 
     override fun onNewData(data: ByteArray) {
-        // T5: Response Receipt at Phone
-        BenchmarkClock.mark(currentIteration.get(), 5)
+        // T6: Response Receipt at Phone
+        BenchmarkClock.mark(currentIteration.get(), 6)
 
         super.onNewData(data)
     }
@@ -45,7 +45,7 @@ internal class LatencyMeasuringUsbSerial @Throws(IOException::class) constructor
 
         super.onCompletePacketReceived(command)
 
-        // T6: Packet Queue Entry
-        BenchmarkClock.mark(currentIteration.get(), 6)
+        // T7: Packet Queue Entry
+        BenchmarkClock.mark(currentIteration.get(), 7)
     }
 }

--- a/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyMeasuringUsbSerial.kt
+++ b/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyMeasuringUsbSerial.kt
@@ -2,11 +2,17 @@ package jp.oist.abcvlib.util.latency
 
 import android.content.Context
 import android.hardware.usb.UsbManager
+import jp.oist.abcvlib.util.AndroidToRP2040Command
 import jp.oist.abcvlib.util.RobotSerialPort
+import jp.oist.abcvlib.util.PacketBuffer
 import jp.oist.abcvlib.util.SerialReadyListener
 import jp.oist.abcvlib.util.UsbSerial
 import jp.oist.abcvlib.util.rp2040.RP2040IncomingCommand
+import jp.oist.abcvlib.util.rp2040.BatteryDetails
+import jp.oist.abcvlib.util.rp2040.ChargeSideUSB
+import jp.oist.abcvlib.util.rp2040.MotorsState
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 internal class LatencyMeasuringUsbSerial @Throws(IOException::class) constructor(
@@ -22,30 +28,105 @@ internal class LatencyMeasuringUsbSerial @Throws(IOException::class) constructor
     port = port
 ) {
 
-    override fun onNewData(data: ByteArray) {
-        // T6: Response Receipt at Phone
-        BenchmarkClock.mark(currentIteration.get(), 6)
+    private val packetPayloadDecoder: (AndroidToRP2040Command, ByteArray) -> PacketBuffer.PacketPayload = { type, data ->
+        val statusPayloadSize =
+            MotorsState.BYTE_LENGTH + BatteryDetails.BYTE_LENGTH + ChargeSideUSB.BYTE_LENGTH
 
-        super.onNewData(data)
+        val isTelemetryEligible = when (type) {
+            AndroidToRP2040Command.GET_STATE,
+            AndroidToRP2040Command.SET_MOTOR_LEVELS,
+            AndroidToRP2040Command.RESET_STATE -> true
+            else -> false
+        }
+
+        if (!isTelemetryEligible || data.size == statusPayloadSize) {
+            PacketBuffer.PacketPayload(data)
+        } else if (data.size == statusPayloadSize + LatencyTelemetry.BYTE_LENGTH) {
+            PacketBuffer.PacketPayload(
+                commandData = data.copyOfRange(0, statusPayloadSize),
+                additionalData = data.copyOfRange(statusPayloadSize, data.size)
+            )
+        } else {
+            PacketBuffer.PacketPayload(data)
+        }
+    }
+
+    override val packetBuffer = PacketBuffer(
+        payloadDecoder = packetPayloadDecoder
+    )
+
+    private val benchmarkTrafficActive = AtomicBoolean(false)
+    private val telemetryUnavailable = AtomicBoolean(false)
+    private var transportDispatchTimestampNs: Long? = null
+    private var responseReceiptTimestampNs: Long? = null
+
+    fun setBenchmarkTrafficActive(isActive: Boolean) {
+        benchmarkTrafficActive.set(isActive)
+    }
+
+    fun assertTelemetryAvailable() {
+        check(!telemetryUnavailable.get()) {
+            "Latency telemetry is unavailable; use telemetry-capable firmware"
+        }
     }
 
     override fun send(packet: ByteArray, timeout: Int) {
         // T3: Transport Dispatch
-        BenchmarkClock.mark(currentIteration.get(), 3)
+        if (benchmarkTrafficActive.get()) {
+            transportDispatchTimestampNs = BenchmarkClock.mark(currentIteration.get(), 3)
+        }
 
         super.send(packet, timeout)
-
-        // T4: Android Write Complete
-        BenchmarkClock.mark(currentIteration.get(), 4)
     }
 
-    override fun onCompletePacketReceived(command: RP2040IncomingCommand) {
+    override fun onNewData(data: ByteArray) {
+        // T6: Response Receipt at Phone
+        if (benchmarkTrafficActive.get()) {
+            responseReceiptTimestampNs = BenchmarkClock.mark(currentIteration.get(), 6)
+        }
+
+        super.onNewData(data)
+    }
+
+    override fun onCompletePacketReceived(
+        command: RP2040IncomingCommand,
+        additionalData: ByteArray?
+    ) {
+        if (command is RP2040IncomingCommand.SetMotorLevels) {
+            recordLatencyTelemetry(additionalData)
+        }
+
+        super.onCompletePacketReceived(command, additionalData)
+
         if (command !is RP2040IncomingCommand.SetMotorLevels)
             return
 
-        super.onCompletePacketReceived(command)
-
         // T7: Packet Queue Entry
         BenchmarkClock.mark(currentIteration.get(), 7)
+    }
+
+    private fun recordLatencyTelemetry(additionalData: ByteArray?) {
+        val telemetry = additionalData?.let(LatencyTelemetry::from)
+            ?: run {
+                telemetryUnavailable.set(true)
+                return
+            }
+
+        val transportDispatchNs = transportDispatchTimestampNs ?: return
+        val responseReceiptNs = responseReceiptTimestampNs ?: return
+
+        val firmwareReceiptNs = telemetry.t4TimestampUs * 1_000L
+        val firmwareProcessingDoneNs = telemetry.t5TimestampUs * 1_000L
+        // The phone and firmware clocks are not synchronized. Place the clock
+        // offset at the midpoint and report the resulting transit as symmetric.
+        val transitMidpointNs = (transportDispatchNs + responseReceiptNs) / 2
+        val calculatedT4 = transitMidpointNs - (firmwareProcessingDoneNs - firmwareReceiptNs) / 2
+        val calculatedT5 = transitMidpointNs + (firmwareProcessingDoneNs - firmwareReceiptNs) / 2
+        val iteration = currentIteration.get()
+
+        BenchmarkClock.markAt(iteration, 4, calculatedT4)
+        BenchmarkClock.markAt(iteration, 5, calculatedT5)
+        transportDispatchTimestampNs = null
+        responseReceiptTimestampNs = null
     }
 }

--- a/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyTelemetry.kt
+++ b/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/latency/LatencyTelemetry.kt
@@ -1,0 +1,36 @@
+package jp.oist.abcvlib.util.latency
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+data class LatencyTelemetry(
+    val t4TimestampUs: Long,
+    val t5TimestampUs: Long
+) {
+    fun toBytes(): ByteArray {
+        val buffer = ByteBuffer.allocate(BYTE_LENGTH).apply {
+            order(ByteOrder.LITTLE_ENDIAN)
+            putLong(t4TimestampUs)
+            putLong(t5TimestampUs)
+        }
+
+        return buffer.array()
+    }
+
+    companion object {
+        const val BYTE_LENGTH = 16
+
+        fun from(bytes: ByteArray): LatencyTelemetry? {
+            if (bytes.size != BYTE_LENGTH) return null
+
+            val buffer = ByteBuffer.wrap(bytes).apply {
+                order(ByteOrder.LITTLE_ENDIAN)
+            }
+
+            return LatencyTelemetry(
+                t4TimestampUs = buffer.long,
+                t5TimestampUs = buffer.long
+            )
+        }
+    }
+}

--- a/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/rp2040/MockRP2040.kt
+++ b/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/rp2040/MockRP2040.kt
@@ -1,5 +1,6 @@
 package jp.oist.abcvlib.util.rp2040
 
+import jp.oist.abcvlib.util.latency.BenchmarkClock
 import jp.oist.abcvlib.util.AndroidToRP2040Command
 /**
  * A simulator for the RP2040 firmware behavior.
@@ -22,6 +23,11 @@ internal class MockRP2040 {
     var onCommandProcessed: ((AndroidToRP2040Command) -> Unit)? = null
 
     /**
+     * Optional hook used by latency benchmarks to tag the firmware processing boundary.
+     */
+    var benchmarkIterationProvider: (() -> Int)? = null
+
+    /**
      * Processes an incoming raw packet and returns a response packet.
      * Mimics the firmware's request-response cycle.
      */
@@ -38,6 +44,9 @@ internal class MockRP2040 {
         // Simulate firmware processing time to prevent race conditions in tests.
         // This ensures the Android side has time to enter its 'await' state.
         Thread.sleep(5)
+
+        // T5: Firmware Processing Complete
+        BenchmarkClock.mark(benchmarkIterationProvider?.invoke() ?: -1, 5)
         
         val typeByte = packet[1]
         val type = AndroidToRP2040Command.getEnumByValue(typeByte) ?: return null

--- a/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/rp2040/MockRP2040.kt
+++ b/libs/abcvlib/src/androidTest/kotlin/jp/oist/abcvlib/util/rp2040/MockRP2040.kt
@@ -1,7 +1,9 @@
 package jp.oist.abcvlib.util.rp2040
 
-import jp.oist.abcvlib.util.latency.BenchmarkClock
+import jp.oist.abcvlib.util.latency.LatencyTelemetry
 import jp.oist.abcvlib.util.AndroidToRP2040Command
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 /**
  * A simulator for the RP2040 firmware behavior.
  * This class maintains a simulated state and responds to incoming commands.
@@ -43,17 +45,24 @@ internal class MockRP2040 {
 
         // Simulate firmware processing time to prevent race conditions in tests.
         // This ensures the Android side has time to enter its 'await' state.
+        val firmwareReceiptUs = System.nanoTime() / 1_000
         Thread.sleep(5)
-
-        // T5: Firmware Processing Complete
-        BenchmarkClock.mark(benchmarkIterationProvider?.invoke() ?: -1, 5)
+        val firmwareProcessingCompleteUs = System.nanoTime() / 1_000
         
         val typeByte = packet[1]
         val type = AndroidToRP2040Command.getEnumByValue(typeByte) ?: return null
+        val telemetry = if (benchmarkIterationProvider != null && type in benchmarkTelemetryTypes) {
+            LatencyTelemetry(
+                t4TimestampUs = firmwareReceiptUs,
+                t5TimestampUs = firmwareProcessingCompleteUs
+            )
+        } else {
+            null
+        }
         
         val response = when (type) {
             AndroidToRP2040Command.GET_STATE -> {
-                generateStatusResponse(AndroidToRP2040Command.GET_STATE)
+                generateStatusResponse(AndroidToRP2040Command.GET_STATE, telemetry)
             }
             AndroidToRP2040Command.SET_MOTOR_LEVELS -> {
                 // Update simulated motor state
@@ -63,12 +72,12 @@ internal class MockRP2040 {
                     
                     logEntries.add("Motors set: L=${motorsState.controlValues.left}, R=${motorsState.controlValues.right}")
                 }
-                generateStatusResponse(AndroidToRP2040Command.SET_MOTOR_LEVELS)
+                generateStatusResponse(AndroidToRP2040Command.SET_MOTOR_LEVELS, telemetry)
             }
             AndroidToRP2040Command.RESET_STATE -> {
                 motorsState = MotorsState()
                 logEntries.add("State reset")
-                generateStatusResponse(AndroidToRP2040Command.RESET_STATE)
+                generateStatusResponse(AndroidToRP2040Command.RESET_STATE, telemetry)
             }
             AndroidToRP2040Command.GET_LOG -> {
                 val logCmd = RP2040IncomingCommand.GetLog(logEntries.toList())
@@ -85,13 +94,47 @@ internal class MockRP2040 {
         return response
     }
 
-    private fun generateStatusResponse(type: AndroidToRP2040Command): ByteArray {
+    private fun generateStatusResponse(
+        type: AndroidToRP2040Command,
+        latencyTelemetry: LatencyTelemetry?
+    ): ByteArray {
         val command = when (type) {
             AndroidToRP2040Command.GET_STATE -> RP2040IncomingCommand.GetState(motorsState, batteryDetails, chargeSideUSB)
             AndroidToRP2040Command.SET_MOTOR_LEVELS -> RP2040IncomingCommand.SetMotorLevels(motorsState, batteryDetails, chargeSideUSB)
             AndroidToRP2040Command.RESET_STATE -> RP2040IncomingCommand.ResetState(motorsState, batteryDetails, chargeSideUSB)
             else -> throw IllegalArgumentException("Invalid status type")
         }
-        return command.toBytes()
+        return if (latencyTelemetry != null) {
+            appendTelemetry(command.toBytes(), latencyTelemetry.toBytes())
+        } else {
+            command.toBytes()
+        }
+    }
+
+    private fun appendTelemetry(packet: ByteArray, telemetry: ByteArray): ByteArray {
+        val baseDataSize = packet.size - 5
+        val extendedPacket = ByteArray(packet.size + telemetry.size)
+
+        extendedPacket[0] = packet[0]
+        extendedPacket[1] = packet[1]
+
+        val newSize = (baseDataSize + telemetry.size).toShort()
+        val sizeBytes = ByteBuffer.allocate(2).order(ByteOrder.LITTLE_ENDIAN).putShort(newSize).array()
+        extendedPacket[2] = sizeBytes[0]
+        extendedPacket[3] = sizeBytes[1]
+
+        System.arraycopy(packet, 4, extendedPacket, 4, baseDataSize)
+        System.arraycopy(telemetry, 0, extendedPacket, 4 + baseDataSize, telemetry.size)
+        extendedPacket[extendedPacket.lastIndex] = packet.last()
+
+        return extendedPacket
+    }
+
+    private companion object {
+        val benchmarkTelemetryTypes = setOf(
+            AndroidToRP2040Command.GET_STATE,
+            AndroidToRP2040Command.SET_MOTOR_LEVELS,
+            AndroidToRP2040Command.RESET_STATE
+        )
     }
 }

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/PacketBuffer.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/PacketBuffer.kt
@@ -5,9 +5,16 @@ import jp.oist.abcvlib.util.rp2040.RP2040IncomingCommand
 import jp.oist.abcvlib.util.rp2040.RP2040ToAndroidPacket
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import java.util.Arrays
 
-class PacketBuffer(capacity: Int = (512 * 128) + 8) {
+class PacketBuffer @JvmOverloads constructor(
+    capacity: Int = (512 * 128) + 8,
+    private val payloadDecoder: ((AndroidToRP2040Command, ByteArray) -> PacketPayload)? = null
+) {
+
+    data class PacketPayload(
+        val commandData: ByteArray,
+        val additionalData: ByteArray? = null
+    )
 
     private var packetDataSize = RP2020_PACKET_SIZE_STATE
     private var packetType: AndroidToRP2040Command = AndroidToRP2040Command.NACK
@@ -71,6 +78,7 @@ class PacketBuffer(capacity: Int = (512 * 128) + 8) {
                     }
 
                     packetType = parsedPacketType
+
                     packetDataSize = _buffer.getShort(startIdx + RP2040ToAndroidPacket.Offsets.DATA_SIZE)
                         .toInt() and 0xFFFF
 
@@ -108,10 +116,11 @@ class PacketBuffer(capacity: Int = (512 * 128) + 8) {
                         packetDataSize
                     )
 
-                    val command = RP2040IncomingCommand.from(packetType, data)
+                    val payload = payloadDecoder?.invoke(packetType, data) ?: PacketPayload(data)
+                    val command = RP2040IncomingCommand.from(packetType, payload.commandData)
                     onResult(
                         command?.let {
-                            ParseResult.ReceivedPacket(it)
+                            ParseResult.ReceivedPacket(it, payload.additionalData)
                         } ?: ParseResult.ReceivedErrorPacket
                     )
 
@@ -189,7 +198,8 @@ class PacketBuffer(capacity: Int = (512 * 128) + 8) {
         object Overflow : ParseResult()
         object ReceivedErrorPacket : ParseResult()
         data class ReceivedPacket(
-            val command: RP2040IncomingCommand
+            val command: RP2040IncomingCommand,
+            val additionalData: ByteArray? = null
         ) : ParseResult()
     }
 

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/UsbSerial.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/UsbSerial.kt
@@ -41,7 +41,7 @@ open class UsbSerial @Throws(IOException::class) constructor(
     private var badPacketCount = 0
 
     internal val fifoQueue: CircularFifoQueue<RP2040IncomingCommand> = CircularFifoQueue<RP2040IncomingCommand>(256)
-    private val packetBuffer = PacketBuffer()
+    protected open val packetBuffer = PacketBuffer()
 
     companion object {
         private const val TAG = "UsbSerial"
@@ -182,7 +182,7 @@ open class UsbSerial @Throws(IOException::class) constructor(
                         }
 
                         is PacketBuffer.ParseResult.ReceivedPacket -> {
-                            onCompletePacketReceived(result.command)
+                            onCompletePacketReceived(result.command, result.additionalData)
 
                             Logger.d(TAG, "Packet verified")
                             Logger.d(TAG, "packetReceived.signal()")
@@ -250,6 +250,17 @@ open class UsbSerial @Throws(IOException::class) constructor(
         }
 
         badPacketCount = 0 // Reset on successful packet
+    }
+
+    /**
+     * Completion hook carrying optional benchmark/diagnostic payload.
+     * The one-argument overload is retained for published-library ABI compatibility.
+     */
+    protected open fun onCompletePacketReceived(
+        command: RP2040IncomingCommand,
+        additionalData: ByteArray?
+    ) {
+        onCompletePacketReceived(command)
     }
 
     protected open fun onBadPacket() {

--- a/libs/abcvlib/src/test/kotlin/jp/oist/abcvlib/util/PacketBufferTest.kt
+++ b/libs/abcvlib/src/test/kotlin/jp/oist/abcvlib/util/PacketBufferTest.kt
@@ -92,6 +92,39 @@ class PacketBufferTest {
     }
 
     @Test
+    fun `test consume packet with telemetry tail`() {
+        val telemetryBytes = ByteArray(16) { it.toByte() }
+        val basePacket = getStateCommand.toBytes()
+        val extendedPacket = appendTelemetry(basePacket, telemetryBytes)
+        val basePayloadSize = basePacket.size - 5
+
+        val packetBufferWithDecoder = PacketBuffer(payloadDecoder = { type, data ->
+            if (type == AndroidToRP2040Command.GET_STATE && data.size == basePayloadSize + telemetryBytes.size) {
+                PacketBuffer.PacketPayload(
+                    commandData = data.copyOfRange(0, basePayloadSize),
+                    additionalData = data.copyOfRange(basePayloadSize, data.size)
+                )
+            } else {
+                PacketBuffer.PacketPayload(data)
+            }
+        })
+
+        packetBufferWithDecoder.consume(extendedPacket) { results.add(it) }
+
+        assertEquals(1, results.size)
+        val result = results[0]
+        assertTrue(result is PacketBuffer.ParseResult.ReceivedPacket)
+        if (result is PacketBuffer.ParseResult.ReceivedPacket) {
+            assertArrayEquals(telemetryBytes, result.additionalData)
+            assertEquals(AndroidToRP2040Command.GET_STATE, result.command.type)
+            assertArrayEquals(
+                basePacket,
+                result.command.toBytes()
+            )
+        }
+    }
+
+    @Test
     fun `test consume multiple complete packets`() {
         val packet1 = getStateCommand.toBytes()
         val packet2 = ackCommand.toBytes()
@@ -150,7 +183,6 @@ class PacketBufferTest {
     @Test
     fun `test consume with leading noise`() {
         val noise = byteArrayOf(0x00, 0x11, 0x22)
-        val payload = byteArrayOf(0x44)
         val packet = resetStateCommand.toBytes()
         val combined = noise + packet
 
@@ -290,5 +322,21 @@ class PacketBufferTest {
         assertEquals("Expected 1 valid packet after overflow recovery", 1, packets.size)
         assertEquals(AndroidToRP2040Command.ACK, packets[0].command.type)
         assertArrayEquals(ackCommand.toBytes(), packets[0].command.toBytes())
+    }
+
+    private fun appendTelemetry(packet: ByteArray, telemetry: ByteArray): ByteArray {
+        val baseDataSize = packet.size - 5
+        val extendedPacket = ByteArray(packet.size + telemetry.size)
+        val newSize = (baseDataSize + telemetry.size).toShort()
+
+        extendedPacket[0] = packet[0]
+        extendedPacket[1] = packet[1]
+        extendedPacket[2] = (newSize.toInt() and 0xFF).toByte()
+        extendedPacket[3] = ((newSize.toInt() shr 8) and 0xFF).toByte()
+        System.arraycopy(packet, 4, extendedPacket, 4, baseDataSize)
+        System.arraycopy(telemetry, 0, extendedPacket, 4 + baseDataSize, telemetry.size)
+        extendedPacket[extendedPacket.lastIndex] = packet.last()
+
+        return extendedPacket
     }
 }


### PR DESCRIPTION
## Summary
- What is in scope for this PR?
Update the latency benchmark flow to support firmware-provided telemetry in the benchmark-only path, keep the
  production packet model unchanged, and derive T4/T5 from telemetry when reporting benchmark results.
- What is intentionally out of scope?
Firmware-side telemetry provider
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Branching
- Milestone base branch: `main`
- This PR branch: `FirmwareBenchmarking/parse-firmware-benchmarks`
- [x] Branch naming follows the required convention.
- [x] Branch is rebased on the current base branch (no merge commit from "Update branch").

## Milestone And Guide
- [x] Milestone tag is set on this PR.

## Scope Declaration
- Exact slice/module in this PR:
  - `abcvlib`
- Related sibling PRs/issues (remaining slices), if any:
  - #247
