### PR TITLE
Move connect outside the UI thread

### DIFF
--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/AbcvlibActivity.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/AbcvlibActivity.kt
@@ -14,11 +14,16 @@ import jp.oist.abcvlib.util.ProcessPriorityThreadFactory
 import jp.oist.abcvlib.util.SerialCommManager
 import jp.oist.abcvlib.util.SerialReadyListener
 import jp.oist.abcvlib.util.UsbSerial
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
-import java.io.IOException
+import kotlinx.coroutines.withContext
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
@@ -42,6 +47,8 @@ abstract class AbcvlibActivity : AppCompatActivity(), SerialReadyListener {
     private var alertDialog: AlertDialog? = null
     private var initialDelay: Long = 0
     private var serialReadyJob: Job? = null
+    private lateinit var serialJob: CompletableJob
+    private lateinit var serialScope: CoroutineScope
 
     // Note anything less than 10ms will result in no GET_STATE commands being called and all
     // being overrides by whatever commands are sent in the main loop
@@ -50,39 +57,52 @@ abstract class AbcvlibActivity : AppCompatActivity(), SerialReadyListener {
     private var mainLoopEnabled = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         isCreated = true
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
+        serialJob = SupervisorJob(lifecycleScope.coroutineContext[Job])
+        serialScope = CoroutineScope(Dispatchers.Default + serialJob)
         usbInitialize()
-        super.onCreate(savedInstanceState)
     }
 
     private fun usbInitialize() {
-        try {
-            val usbManager = getSystemService(USB_SERVICE) as UsbManager
-            this.usbSerial = UsbSerial(
-                context = this,
-                usbManager = usbManager,
-                serialReadyListener = object : SerialReadyListener {
-                    override fun onSerialReady(usbSerial: UsbSerial) {
-                        lifecycleScope.launch {
-                            // Cancel the previous serialReadyJob if it exists to avoid multiple executions in parallel.
-                            serialReadyJob?.cancelAndJoin()
-                            // Call Activity's onSerialReady inside (Dispatchers.Default) to avoid blocking the main thread
-                            serialReadyJob = launch(Dispatchers.Default) {
-                                this@AbcvlibActivity.onSerialReady(usbSerial)
-                            }
+        val usbManager = getSystemService(USB_SERVICE) as UsbManager
+        this.usbSerial = UsbSerial(
+            context = this,
+            usbManager = usbManager,
+            serialReadyListener = object : SerialReadyListener {
+                override fun onSerialReady(usbSerial: UsbSerial) {
+                    // Always post first so a fast connection cannot invoke application callbacks
+                    // while this activity or its subclass is still returning from onCreate().
+                    lifecycleScope.launch(Dispatchers.Main) {
+                        // Cancel the previous readiness callback before scheduling another one.
+                        serialReadyJob?.cancelAndJoin()
+                        serialReadyJob = coroutineContext.job
+                        // Keep application callback work off the main thread.
+                        withContext(Dispatchers.Default) {
+                            this@AbcvlibActivity.onSerialReady(usbSerial)
                         }
                     }
                 }
-            )
-        } catch (e: IOException) {
-            e.printStackTrace()
-            showCustomDialog()
-        }
+            },
+            coroutineScope = serialScope,
+            initialConnectionErrorListener = { error ->
+                error.printStackTrace()
+                runOnUiThread { showCustomDialog() }
+            }
+        )
     }
 
     @WorkerThread
     override fun onSerialReady(usbSerial: UsbSerial) {
+        // An attachment may connect while the missing-robot dialog is visible. Once a
+        // connection succeeds, prevent the dialog from replacing this live serial instance.
+        runOnUiThread {
+            alertDialog?.dismiss()
+            alertDialog = null
+        }
+
         if (serialCommManager == null) {
             Logger.w(
                 TAG, "Default SerialCommManager being used. If you intended to create your " +
@@ -182,6 +202,13 @@ abstract class AbcvlibActivity : AppCompatActivity(), SerialReadyListener {
         // Set a click listener for the Confirm button
         confirmButton.setOnClickListener { // Dismiss the dialog
             alertDialog?.dismiss()
+            if (serialCommManager != null) {
+                alertDialog = null
+                return@setOnClickListener
+            }
+            if (::usbSerial.isInitialized) {
+                usbSerial.close()
+            }
             usbInitialize()
         }
 
@@ -189,6 +216,17 @@ abstract class AbcvlibActivity : AppCompatActivity(), SerialReadyListener {
         alertDialog = builder.create()
         // Show the dialog
         alertDialog?.show()
+    }
+
+    override fun onDestroy() {
+        // Cleanup the serial connection on activity destruction
+        if (::usbSerial.isInitialized) {
+            usbSerial.close()
+        }
+
+        serialScope.cancel()
+
+        super.onDestroy()
     }
 
     override fun onStop() {

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/UsbSerial.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/UsbSerial.kt
@@ -22,6 +22,16 @@ import jp.oist.abcvlib.util.ByteArrayExtensions.toHexString
 import jp.oist.abcvlib.util.ErrorHandler.eLog
 import jp.oist.abcvlib.util.rp2040.RP2040IncomingCommand
 import jp.oist.abcvlib.util.rp2040.RP2040OutgoingCommand
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
 import org.apache.commons.collections4.queue.CircularFifoQueue
 import java.io.IOException
 import java.util.concurrent.TimeUnit
@@ -32,10 +42,18 @@ open class UsbSerial @Throws(IOException::class) constructor(
     private val context: Context,
     private val usbManager: UsbManager,
     private val serialReadyListener: SerialReadyListener,
-    port: RobotSerialPort? = null
+    port: RobotSerialPort? = null,
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    private val initialConnectionErrorListener: ((IOException) -> Unit)? = null
 ) : SerialInputOutputManager.Listener {
 
-    private lateinit var _port: RobotSerialPort
+    private var _port: RobotSerialPort? = null
+    private val stateLock = Any()
+    private var isOpening = false
+    private var usbReceiver: BroadcastReceiver? = null
+    private var connectJob: Job? = null
+    @Volatile
+    private var isClosed = false
 
     private val timeout: Int = 1000 //1s
     private var badPacketCount = 0
@@ -57,42 +75,64 @@ open class UsbSerial @Throws(IOException::class) constructor(
         if (port != null) {
             // If a port is provided (e.g. for testing), we assume it's already "found"
             // and we notify the listener immediately to ensure it's ready for the test.
-            _port = port
-            _port.startReading(this)
+            synchronized(stateLock) {
+                _port = port
+            }
+            port.startReading(this)
             serialReadyListener.onSerialReady(this)
         } else {
-            // Find all available drivers from attached devices.
-            val deviceList = usbManager.deviceList
-
-            if (deviceList.isEmpty()) {
-                throw IOException("No USB devices found")
-            }
-
-            for (d in deviceList.values) {
-                if (d.manufacturerName == "Seeed" && d.productName == "Seeeduino XIAO") {
-                    Logger.i(Thread.currentThread().name, "Found a XIAO. Connecting...")
-                    connect(d)
-                } else if (d.manufacturerName.equals("Raspberry Pi") && d.productName.equals("Pico Test Device")) {
-                    Logger.i(Thread.currentThread().name, "Found a Pico Test Device. Connecting...")
-                    connect(d)
-                } else if (d.manufacturerName == "Raspberry Pi" && d.productName == "Pico") {
-                    Logger.i(Thread.currentThread().name, "Found a Pi. Connecting...")
-                    connect(d)
-                }
-            }
+            // Registration is UI-safe. Preserve the constructor's automatic startup behavior,
+            // but perform enumeration and connection on the IO dispatcher.
             val filter = IntentFilter(ACTION_USB_PERMISSION).apply {
                 addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED)
             }
-            val usbReceiver: BroadcastReceiver = MyBroadcastReceiver()
-            ContextCompat.registerReceiver(context, usbReceiver, filter, RECEIVER_NOT_EXPORTED)
+            val receiver = MyBroadcastReceiver()
+            usbReceiver = receiver
+            ContextCompat.registerReceiver(context, receiver, filter, RECEIVER_NOT_EXPORTED)
+            connectJob = coroutineScope.launch(Dispatchers.IO) {
+                try {
+                    connect()
+                } catch (e: IOException) {
+                    Logger.e(TAG, "Initial USB connection failed: ${e.localizedMessage}")
+                    initialConnectionErrorListener?.invoke(e)
+                }
+            }
         }
     }
 
+    /** Enumerates devices and opens the selected port. Call from a background dispatcher. */
     @Throws(IOException::class)
-    private fun connect(device: UsbDevice) {
+    suspend fun connect() = withContext(Dispatchers.IO) {
+        currentCoroutineContext().ensureActive()
+        if (isClosed) return@withContext
+
+        val deviceList = usbManager.deviceList
+        if (deviceList.isEmpty()) {
+            throw IOException("No USB devices found")
+        }
+
+        for (device in deviceList.values) {
+            if (isSupportedDevice(device)) {
+                Logger.i(Thread.currentThread().name, "Found a supported USB device. Connecting...")
+                connect(device)
+                return@withContext
+            }
+        }
+        throw IOException("No supported USB devices found")
+    }
+
+    private fun isSupportedDevice(device: UsbDevice): Boolean =
+        device.manufacturerName == "Seeed" && device.productName == "Seeeduino XIAO" ||
+            device.manufacturerName == "Raspberry Pi" &&
+            (device.productName == "Pico Test Device" || device.productName == "Pico")
+
+    @Throws(IOException::class)
+    private suspend fun connect(device: UsbDevice) {
+        currentCoroutineContext().ensureActive()
         if (usbManager.hasPermission(device)) {
             Logger.i(Thread.currentThread().name, "Has permission to connect to device")
-            val connection: UsbDeviceConnection = usbManager.openDevice(device)
+            val connection = usbManager.openDevice(device)
+                ?: throw IOException("Failed to open USB device connection")
             openPort(connection)
         } else {
             Logger.i(Thread.currentThread().name, "Requesting permission to connect to device")
@@ -112,26 +152,75 @@ open class UsbSerial @Throws(IOException::class) constructor(
         }
     }
 
-    private fun openPort(connection: UsbDeviceConnection) {
+    private suspend fun openPort(connection: UsbDeviceConnection) {
+        synchronized(stateLock) {
+            if (isClosed || _port != null || isOpening) {
+                connection.close()
+                return
+            }
+            isOpening = true
+        }
+
+        try {
+            openPortInternal(connection)
+        } finally {
+            synchronized(stateLock) {
+                isOpening = false
+            }
+        }
+    }
+
+    private suspend fun openPortInternal(connection: UsbDeviceConnection) {
         Logger.i(Thread.currentThread().name, "Opening port")
         val driver = getDriver()
         val usbSerialPort = driver.ports[0] // Most devices have just one port (port 0)
+        val realPort = RealRobotSerialPort(usbSerialPort)
         try {
-            val realPort = RealRobotSerialPort(usbSerialPort)
             realPort.open(connection)
             realPort.setParameters(115200, 8, 1, UsbSerialPort.PARITY_NONE)
             realPort.setDtr(true)
             
-            this._port = realPort
+            synchronized(stateLock) {
+                if (isClosed) {
+                    realPort.close()
+                    return
+                }
+                _port = realPort
+            }
             
             // Adding this as there doesn't appear to be any call back in the usbIoManager that
             // will call onSerialReady after initialization. As it stands, there were things occurring
             // in onSerialReady that were being executed before the usbIoManager was initialized.
-            Thread.sleep(100)
-            realPort.startReading(this)
+            delay(100)
+            synchronized(stateLock) {
+                if (isClosed || _port !== realPort) {
+                    if (_port === realPort) _port = null
+                    realPort.close()
+                    return
+                }
+                realPort.startReading(this)
+            }
             serialReadyListener.onSerialReady(this)
         } catch (e: IOException) {
+            synchronized(stateLock) {
+                if (_port === realPort) _port = null
+            }
+            try {
+                realPort.close()
+            } catch (_: IOException) {
+                // Preserve the original connection error.
+            }
             e.printStackTrace()
+        } catch (e: CancellationException) {
+            synchronized(stateLock) {
+                if (_port === realPort) _port = null
+            }
+            try {
+                realPort.close()
+            } catch (_: IOException) {
+                // Preserve cancellation while still attempting cleanup.
+            }
+            throw e
         } catch (e: InterruptedException) {
             throw RuntimeException(e)
         }
@@ -204,7 +293,9 @@ open class UsbSerial @Throws(IOException::class) constructor(
 
     @Throws(IOException::class)
     internal open fun send(packet: ByteArray, timeout: Int) {
-        _port.write(packet, timeout)
+        val port = synchronized(stateLock) { _port }
+            ?: throw IOException("Port is not open")
+        port.write(packet, timeout)
         Logger.i(Thread.currentThread().name, "send()")
     }
 
@@ -273,6 +364,27 @@ open class UsbSerial @Throws(IOException::class) constructor(
         e.printStackTrace()
     }
 
+    internal fun close() {
+        val port = synchronized(stateLock) {
+            isClosed = true
+            _port.also { _port = null }
+        }
+        connectJob?.cancel()
+        try {
+            port?.close()
+        } catch (e: IOException) {
+            Logger.e(TAG, "Failed to close USB port: ${e.localizedMessage}")
+        }
+        usbReceiver?.let {
+            try {
+                context.unregisterReceiver(it)
+            } catch (_: IllegalArgumentException) {
+                // Receiver was already unregistered.
+            }
+        }
+        usbReceiver = null
+    }
+
     private inner class MyBroadcastReceiver : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             val device = IntentCompat.getParcelableExtra(
@@ -280,16 +392,23 @@ open class UsbSerial @Throws(IOException::class) constructor(
                 UsbManager.EXTRA_DEVICE,
                 UsbDevice::class.java
             )
-            if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
-                val action = intent.action
-                if (ACTION_USB_PERMISSION == action) {
-                    synchronized(this) {
+            val action = intent.action
+            if (device != null && isSupportedDevice(device) &&
+                (ACTION_USB_PERMISSION == action || UsbManager.ACTION_USB_DEVICE_ATTACHED == action)
+            ) {
+                if (ACTION_USB_PERMISSION != action ||
+                    intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)
+                ) {
+                    connectJob?.cancel()
+                    connectJob = coroutineScope.launch(Dispatchers.IO) {
                         try {
-                            connect(device!!)
+                            connect(device)
                         } catch (e: IOException) {
-                            e.printStackTrace()
+                            Logger.e(TAG, "USB connection failed: ${e.localizedMessage}")
                         }
                     }
+                } else {
+                    Logger.d("serial", "permission denied for device $device")
                 }
             } else {
                 Logger.d("serial", "permission denied for device $device")


### PR DESCRIPTION
## Summary
- What is in scope for this PR?
Moving connection to USB devices rom UI thread to a separate one.
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Scope Declaration
- Exact slice/module in this PR:
  - `libs/abcvlib/src/main/java/jp/oist/abcvlib/core/AbcvlibActivity.kt`
  - `libs/abcvlib/src/main/java/jp/oist/abcvlib/util/UsbSerial.kt`
- Related sibling PRs/issues (remaining slices), if any:
  - #61
