### PR TITLE
Keep existing model assets during preBuild

### DIFF
--- a/build-logic/convention/src/main/kotlin/jp/oist/abcvlib/ModelDownload.kt
+++ b/build-logic/convention/src/main/kotlin/jp/oist/abcvlib/ModelDownload.kt
@@ -22,7 +22,7 @@ object ModelDownload {
                 tasks.register<Download>("download_${name.replace(".", "_")}") {
                     src(url)
                     dest("$assetDir/$name")
-                    overwrite(name == "model.tflite")
+                    overwrite(false)
                 }
             }
 

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/phone/MicrophoneData.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/phone/MicrophoneData.kt
@@ -2,6 +2,7 @@ package jp.oist.abcvlib.core.inputs.phone
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.AlertDialog
 import android.content.Context
 import android.media.AudioFormat
 import android.media.AudioRecord
@@ -10,6 +11,7 @@ import android.media.AudioTimestamp
 import android.media.MediaRecorder
 import android.os.Handler
 import android.os.HandlerThread
+import android.os.SystemClock
 import com.intentfilter.androidpermissions.models.DeniedPermissions
 import jp.oist.abcvlib.core.inputs.Publisher
 import jp.oist.abcvlib.core.inputs.PublisherManager
@@ -29,6 +31,7 @@ open class MicrophoneData(
 
     private lateinit var audioExecutor: ScheduledExecutorServiceWithException
     private lateinit var recorder: AudioRecord
+    private var microphoneAvailable = true
 
     class Builder(
         private val context: Context,
@@ -40,14 +43,28 @@ open class MicrophoneData(
     }
 
     override fun start() {
-        recorder.startRecording()
+        try {
+            recorder.startRecording()
+        } catch (e: IllegalStateException) {
+            failMicrophoneStartup(e)
+            return
+        }
+        if (recorder.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
+            failMicrophoneStartup()
+            return
+        }
 
-        while (recorder.getTimestamp(
-                _startTime,
-                AudioTimestamp.TIMEBASE_MONOTONIC
-            ) == AudioRecord.ERROR_INVALID_OPERATION
+        val timeoutAtMs = SystemClock.uptimeMillis() + MICROPHONE_START_TIMEOUT_MS
+        var timestampStatus = recorder.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
+        while (timestampStatus == AudioRecord.ERROR_INVALID_OPERATION &&
+            SystemClock.uptimeMillis() < timeoutAtMs
         ) {
-            recorder.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
+            Thread.sleep(MICROPHONE_TIMESTAMP_RETRY_DELAY_MS)
+            timestampStatus = recorder.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
+        }
+        if (timestampStatus == AudioRecord.ERROR_INVALID_OPERATION) {
+            failMicrophoneStartup()
+            return
         }
         Logger.i(
             "microphone_start",
@@ -58,10 +75,16 @@ open class MicrophoneData(
     }
 
     override fun stop() {
-        recorder.stop()
-        recorder.setRecordPositionUpdateListener(null)
-        audioExecutor.shutdownNow()
-        recorder.release()
+        if (microphoneAvailable) {
+            recorder.stop()
+            recorder.setRecordPositionUpdateListener(null)
+        }
+        if (::audioExecutor.isInitialized) {
+            audioExecutor.shutdownNow()
+        }
+        if (::recorder.isInitialized) {
+            recorder.release()
+        }
         super.stop()
     }
 
@@ -174,6 +197,31 @@ open class MicrophoneData(
 
     override fun onPermissionDenied(deniedPermissions: DeniedPermissions) {
         ErrorHandler.eLog(TAG, "This app requires Audio Recording", Exception(), true)
+    }
+
+    private fun failMicrophoneStartup(cause: Exception? = null) {
+        microphoneAvailable = false
+        Logger.e(
+            TAG,
+            "Microphone did not become available. Another abcvlib app may still be using audio recording.",
+            cause ?: Exception("Microphone unavailable")
+        )
+        Handler(context.mainLooper).post {
+            AlertDialog.Builder(context)
+                .setTitle("Microphone unavailable")
+                .setMessage(
+                    "Close other abcvlib apps that may be using the microphone, then restart this app."
+                )
+                .setPositiveButton("OK", null)
+                .show()
+        }
+        publisherManager.onPublisherInitialized()
+        super.start()
+    }
+
+    companion object {
+        private const val MICROPHONE_START_TIMEOUT_MS = 2_000L
+        private const val MICROPHONE_TIMESTAMP_RETRY_DELAY_MS = 20L
     }
     /*        public void processAudioFrame(short[] audioFrame) {
                 final double bufferLength = 20; //milliseconds

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/phone/MicrophoneData.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/phone/MicrophoneData.kt
@@ -29,8 +29,9 @@ open class MicrophoneData(
     private val _startTime: AudioTimestamp = AudioTimestamp()
     private val _endTime: AudioTimestamp = AudioTimestamp()
 
-    private lateinit var audioExecutor: ScheduledExecutorServiceWithException
-    private lateinit var recorder: AudioRecord
+    private var audioExecutor: ScheduledExecutorServiceWithException? = null
+    private var recorder: AudioRecord? = null
+    private var audioHandlerThread: HandlerThread? = null
     private var microphoneAvailable = true
 
     class Builder(
@@ -43,24 +44,28 @@ open class MicrophoneData(
     }
 
     override fun start() {
+        val activeRecorder = recorder ?: run {
+            failMicrophoneStartup(IllegalStateException("AudioRecord was not initialized"))
+            return
+        }
         try {
-            recorder.startRecording()
+            activeRecorder.startRecording()
         } catch (e: IllegalStateException) {
             failMicrophoneStartup(e)
             return
         }
-        if (recorder.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
+        if (activeRecorder.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
             failMicrophoneStartup()
             return
         }
 
         val timeoutAtMs = SystemClock.uptimeMillis() + MICROPHONE_START_TIMEOUT_MS
-        var timestampStatus = recorder.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
+        var timestampStatus = activeRecorder.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
         while (timestampStatus == AudioRecord.ERROR_INVALID_OPERATION &&
             SystemClock.uptimeMillis() < timeoutAtMs
         ) {
             Thread.sleep(MICROPHONE_TIMESTAMP_RETRY_DELAY_MS)
-            timestampStatus = recorder.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
+            timestampStatus = activeRecorder.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
         }
         if (timestampStatus == AudioRecord.ERROR_INVALID_OPERATION) {
             failMicrophoneStartup()
@@ -75,16 +80,7 @@ open class MicrophoneData(
     }
 
     override fun stop() {
-        if (microphoneAvailable) {
-            recorder.stop()
-            recorder.setRecordPositionUpdateListener(null)
-        }
-        if (::audioExecutor.isInitialized) {
-            audioExecutor.shutdownNow()
-        }
-        if (::recorder.isInitialized) {
-            recorder.release()
-        }
+        cleanupAudioResources()
         super.stop()
     }
 
@@ -99,17 +95,17 @@ open class MicrophoneData(
     }
 
     fun setStartTime() {
-        recorder.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
+        recorder?.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
     }
 
 
     fun getEndTime(): AudioTimestamp {
-        recorder.getTimestamp(_endTime, AudioTimestamp.TIMEBASE_MONOTONIC)
+        recorder?.getTimestamp(_endTime, AudioTimestamp.TIMEBASE_MONOTONIC)
         return _endTime
     }
 
     fun getSampleRate(): Int {
-        return recorder.sampleRate
+        return recorder?.sampleRate ?: 0
     }
 
     override fun onMarkerReached(recorder: AudioRecord) {
@@ -126,8 +122,15 @@ open class MicrophoneData(
      * @param audioRecord
      */
     override fun onPeriodicNotification(audioRecord: AudioRecord) {
+        if (!microphoneAvailable) {
+            return
+        }
+        val executor = audioExecutor ?: return
         try {
-            audioExecutor.execute {
+            executor.execute {
+                if (!microphoneAvailable) {
+                    return@execute
+                }
                 val readBufferSize = audioRecord.positionNotificationPeriod
                 val audioData = FloatArray(readBufferSize)
                 @SuppressLint("WrongConstant") val numSamples = audioRecord.read(
@@ -145,7 +148,7 @@ open class MicrophoneData(
     }
 
     protected fun onNewAudioData(audioData: FloatArray, numSamples: Int) {
-        if (subscribers.isNotEmpty() && !paused) {
+        if (microphoneAvailable && subscribers.isNotEmpty() && !paused) {
             for (subscriber in subscribers) {
                 subscriber.onMicrophoneDataUpdate(
                     audioData,
@@ -162,9 +165,8 @@ open class MicrophoneData(
     override fun onPermissionGranted() {
         val priority = ProcessPriorityThreadFactory(10, "dataGatherer")
         audioExecutor = ScheduledExecutorServiceWithException(1, priority)
-        val handlerThread = HandlerThread("audioHandlerThread")
-        handlerThread.start()
-        val handler = Handler(handlerThread.looper)
+        audioHandlerThread = HandlerThread("audioHandlerThread").also { it.start() }
+        val handler = Handler(audioHandlerThread!!.looper)
 
         val mAudioSource = MediaRecorder.AudioSource.UNPROCESSED
         val mSampleRate = 8000
@@ -183,15 +185,16 @@ open class MicrophoneData(
         } catch (e: SecurityException) {
             throw RuntimeException("You must grant audio record access to use this app")
         }
+        val activeRecorder = recorder ?: throw IllegalStateException("AudioRecord was not created")
 
         val bytesPerSample = 32 / 8 // 32 bits per sample (Float.size), 8 bytes per bit.
         // Need this as setPositionNotificationPeriod takes num of frames as period, and you want it to fire after each full cycle through the buffer.
-        val bytesPerFrame = bytesPerSample * recorder.channelCount
+        val bytesPerFrame = bytesPerSample * activeRecorder.channelCount
         val framePerBuffer =
             bufferSize / bytesPerFrame // # of frames that can be kept in a bufferSize dimension
         val framePeriod = framePerBuffer / 2 // Read from buffer two times per full buffer.
-        recorder.positionNotificationPeriod = framePeriod
-        recorder.setRecordPositionUpdateListener(this, handler)
+        activeRecorder.positionNotificationPeriod = framePeriod
+        activeRecorder.setRecordPositionUpdateListener(this, handler)
         publisherManager.onPublisherPermissionsGranted(this)
     }
 
@@ -215,8 +218,27 @@ open class MicrophoneData(
                 .setPositiveButton("OK", null)
                 .show()
         }
+        cleanupAudioResources()
         publisherManager.onPublisherInitialized()
-        super.start()
+    }
+
+    private fun cleanupAudioResources() {
+        recorder?.let { activeRecorder ->
+            activeRecorder.setRecordPositionUpdateListener(null)
+            if (activeRecorder.recordingState == AudioRecord.RECORDSTATE_RECORDING) {
+                try {
+                    activeRecorder.stop()
+                } catch (e: IllegalStateException) {
+                    Logger.w(TAG, "Unable to stop microphone during cleanup", e)
+                }
+            }
+            activeRecorder.release()
+            recorder = null
+        }
+        audioExecutor?.shutdownNow()
+        audioExecutor = null
+        audioHandlerThread?.quitSafely()
+        audioHandlerThread = null
     }
 
     companion object {

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/phone/MicrophoneData.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/phone/MicrophoneData.kt
@@ -2,7 +2,6 @@ package jp.oist.abcvlib.core.inputs.phone
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.app.AlertDialog
 import android.content.Context
 import android.media.AudioFormat
 import android.media.AudioRecord
@@ -11,7 +10,6 @@ import android.media.AudioTimestamp
 import android.media.MediaRecorder
 import android.os.Handler
 import android.os.HandlerThread
-import android.os.SystemClock
 import com.intentfilter.androidpermissions.models.DeniedPermissions
 import jp.oist.abcvlib.core.inputs.Publisher
 import jp.oist.abcvlib.core.inputs.PublisherManager
@@ -29,10 +27,8 @@ open class MicrophoneData(
     private val _startTime: AudioTimestamp = AudioTimestamp()
     private val _endTime: AudioTimestamp = AudioTimestamp()
 
-    private var audioExecutor: ScheduledExecutorServiceWithException? = null
-    private var recorder: AudioRecord? = null
-    private var audioHandlerThread: HandlerThread? = null
-    private var microphoneAvailable = true
+    private lateinit var audioExecutor: ScheduledExecutorServiceWithException
+    private lateinit var recorder: AudioRecord
 
     class Builder(
         private val context: Context,
@@ -44,32 +40,14 @@ open class MicrophoneData(
     }
 
     override fun start() {
-        val activeRecorder = recorder ?: run {
-            failMicrophoneStartup(IllegalStateException("AudioRecord was not initialized"))
-            return
-        }
-        try {
-            activeRecorder.startRecording()
-        } catch (e: IllegalStateException) {
-            failMicrophoneStartup(e)
-            return
-        }
-        if (activeRecorder.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
-            failMicrophoneStartup()
-            return
-        }
+        recorder.startRecording()
 
-        val timeoutAtMs = SystemClock.uptimeMillis() + MICROPHONE_START_TIMEOUT_MS
-        var timestampStatus = activeRecorder.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
-        while (timestampStatus == AudioRecord.ERROR_INVALID_OPERATION &&
-            SystemClock.uptimeMillis() < timeoutAtMs
+        while (recorder.getTimestamp(
+                _startTime,
+                AudioTimestamp.TIMEBASE_MONOTONIC
+            ) == AudioRecord.ERROR_INVALID_OPERATION
         ) {
-            Thread.sleep(MICROPHONE_TIMESTAMP_RETRY_DELAY_MS)
-            timestampStatus = activeRecorder.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
-        }
-        if (timestampStatus == AudioRecord.ERROR_INVALID_OPERATION) {
-            failMicrophoneStartup()
-            return
+            recorder.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
         }
         Logger.i(
             "microphone_start",
@@ -80,7 +58,10 @@ open class MicrophoneData(
     }
 
     override fun stop() {
-        cleanupAudioResources()
+        recorder.stop()
+        recorder.setRecordPositionUpdateListener(null)
+        audioExecutor.shutdownNow()
+        recorder.release()
         super.stop()
     }
 
@@ -95,17 +76,17 @@ open class MicrophoneData(
     }
 
     fun setStartTime() {
-        recorder?.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
+        recorder.getTimestamp(_startTime, AudioTimestamp.TIMEBASE_MONOTONIC)
     }
 
 
     fun getEndTime(): AudioTimestamp {
-        recorder?.getTimestamp(_endTime, AudioTimestamp.TIMEBASE_MONOTONIC)
+        recorder.getTimestamp(_endTime, AudioTimestamp.TIMEBASE_MONOTONIC)
         return _endTime
     }
 
     fun getSampleRate(): Int {
-        return recorder?.sampleRate ?: 0
+        return recorder.sampleRate
     }
 
     override fun onMarkerReached(recorder: AudioRecord) {
@@ -122,15 +103,8 @@ open class MicrophoneData(
      * @param audioRecord
      */
     override fun onPeriodicNotification(audioRecord: AudioRecord) {
-        if (!microphoneAvailable) {
-            return
-        }
-        val executor = audioExecutor ?: return
         try {
-            executor.execute {
-                if (!microphoneAvailable) {
-                    return@execute
-                }
+            audioExecutor.execute {
                 val readBufferSize = audioRecord.positionNotificationPeriod
                 val audioData = FloatArray(readBufferSize)
                 @SuppressLint("WrongConstant") val numSamples = audioRecord.read(
@@ -148,7 +122,7 @@ open class MicrophoneData(
     }
 
     protected fun onNewAudioData(audioData: FloatArray, numSamples: Int) {
-        if (microphoneAvailable && subscribers.isNotEmpty() && !paused) {
+        if (subscribers.isNotEmpty() && !paused) {
             for (subscriber in subscribers) {
                 subscriber.onMicrophoneDataUpdate(
                     audioData,
@@ -165,8 +139,9 @@ open class MicrophoneData(
     override fun onPermissionGranted() {
         val priority = ProcessPriorityThreadFactory(10, "dataGatherer")
         audioExecutor = ScheduledExecutorServiceWithException(1, priority)
-        audioHandlerThread = HandlerThread("audioHandlerThread").also { it.start() }
-        val handler = Handler(audioHandlerThread!!.looper)
+        val handlerThread = HandlerThread("audioHandlerThread")
+        handlerThread.start()
+        val handler = Handler(handlerThread.looper)
 
         val mAudioSource = MediaRecorder.AudioSource.UNPROCESSED
         val mSampleRate = 8000
@@ -185,65 +160,20 @@ open class MicrophoneData(
         } catch (e: SecurityException) {
             throw RuntimeException("You must grant audio record access to use this app")
         }
-        val activeRecorder = recorder ?: throw IllegalStateException("AudioRecord was not created")
 
         val bytesPerSample = 32 / 8 // 32 bits per sample (Float.size), 8 bytes per bit.
         // Need this as setPositionNotificationPeriod takes num of frames as period, and you want it to fire after each full cycle through the buffer.
-        val bytesPerFrame = bytesPerSample * activeRecorder.channelCount
+        val bytesPerFrame = bytesPerSample * recorder.channelCount
         val framePerBuffer =
             bufferSize / bytesPerFrame // # of frames that can be kept in a bufferSize dimension
         val framePeriod = framePerBuffer / 2 // Read from buffer two times per full buffer.
-        activeRecorder.positionNotificationPeriod = framePeriod
-        activeRecorder.setRecordPositionUpdateListener(this, handler)
+        recorder.positionNotificationPeriod = framePeriod
+        recorder.setRecordPositionUpdateListener(this, handler)
         publisherManager.onPublisherPermissionsGranted(this)
     }
 
     override fun onPermissionDenied(deniedPermissions: DeniedPermissions) {
         ErrorHandler.eLog(TAG, "This app requires Audio Recording", Exception(), true)
-    }
-
-    private fun failMicrophoneStartup(cause: Exception? = null) {
-        microphoneAvailable = false
-        Logger.e(
-            TAG,
-            "Microphone did not become available. Another abcvlib app may still be using audio recording.",
-            cause ?: Exception("Microphone unavailable")
-        )
-        Handler(context.mainLooper).post {
-            AlertDialog.Builder(context)
-                .setTitle("Microphone unavailable")
-                .setMessage(
-                    "Close other abcvlib apps that may be using the microphone, then restart this app."
-                )
-                .setPositiveButton("OK", null)
-                .show()
-        }
-        cleanupAudioResources()
-        publisherManager.onPublisherInitialized()
-    }
-
-    private fun cleanupAudioResources() {
-        recorder?.let { activeRecorder ->
-            activeRecorder.setRecordPositionUpdateListener(null)
-            if (activeRecorder.recordingState == AudioRecord.RECORDSTATE_RECORDING) {
-                try {
-                    activeRecorder.stop()
-                } catch (e: IllegalStateException) {
-                    Logger.w(TAG, "Unable to stop microphone during cleanup", e)
-                }
-            }
-            activeRecorder.release()
-            recorder = null
-        }
-        audioExecutor?.shutdownNow()
-        audioExecutor = null
-        audioHandlerThread?.quitSafely()
-        audioHandlerThread = null
-    }
-
-    companion object {
-        private const val MICROPHONE_START_TIMEOUT_MS = 2_000L
-        private const val MICROPHONE_TIMESTAMP_RETRY_DELAY_MS = 20L
     }
     /*        public void processAudioFrame(short[] audioFrame) {
                 final double bufferLength = 20; //milliseconds


### PR DESCRIPTION
## Summary
- stop Gradle from overwriting existing model assets during `preBuild`

## Notes
This keeps the model-download behavior from the tutorial branch while removing the microphone startup changes from this PR.

Microphone and other publisher startup failures will be handled separately in #319.

## Tests
- `./gradlew :abcvlib:compileDebugKotlin --offline`
