### PR TITLE
Publish immutable timestep snapshots

### DIFF
--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/TimeStepDataBuffer.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/TimeStepDataBuffer.kt
@@ -44,6 +44,9 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
     val imgCompFuturesEpisode: MutableCollection<MutableCollection<Future<*>>> =
         Collections.synchronizedList(LinkedList())
 
+    private val imgCompFuturesByIndex: Array<MutableList<Future<*>>> =
+        Array(bufferLength) { Collections.synchronizedList(LinkedList()) }
+
     private val imageCompressionExecutor: ExecutorService = Executors.newCachedThreadPool(
         ProcessPriorityThreadFactory(Thread.MAX_PRIORITY, "ImageCompression")
     )
@@ -51,15 +54,25 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
     @Synchronized
     fun nextTimeStep() {
         // Keeps track of how many image compression threads have yet to finish per timestep
-        imgCompFuturesEpisode.add(imgCompFuturesTimeStep)
-        imgCompFuturesTimeStep.clear()
+        val completedFutures = getImageCompressionFutures(writeIndex)
+        val episodeFutures = Collections.synchronizedList(LinkedList<Future<*>>())
+        episodeFutures.addAll(completedFutures)
+        imgCompFuturesEpisode.add(episodeFutures)
+
+        writeData.freeze()
 
         // Update index for read and write pointer
         writeIndex = ((writeIndex + 1) % bufferLength)
         readIndex = ((readIndex + 1) % bufferLength)
 
-        // Clear the next TimeStepData object for new writing
-        buffer[writeIndex].clear()
+        // Replace the next write slot so async readers can keep using the old frozen object.
+        buffer[writeIndex] = TimeStepData()
+        synchronized(imgCompFuturesByIndex[writeIndex]) {
+            imgCompFuturesByIndex[writeIndex].clear()
+        }
+        synchronized(imgCompFuturesTimeStep) {
+            imgCompFuturesTimeStep.clear()
+        }
 
         // Move pointer for reading and writing objects one index forward;
         writeData = buffer[writeIndex]
@@ -86,18 +99,28 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
         return readIndex
     }
 
-    override fun onBatteryVoltageUpdate(timestamp: Long, voltage: Double) {
-        getWriteData().batteryData.put(voltage, timestamp)
+    fun getImageCompressionFutures(timestep: Int): List<Future<*>> {
+        val futures = imgCompFuturesByIndex[timestep]
+        synchronized(futures) {
+            return futures.toList()
+        }
     }
 
+    @Synchronized
+    override fun onBatteryVoltageUpdate(timestamp: Long, voltage: Double) {
+        writeData.batteryData.put(voltage, timestamp)
+    }
+
+    @Synchronized
     override fun onChargerVoltageUpdate(
         timestamp: Long,
         chargerVoltage: Double,
         coilVoltage: Double
     ) {
-        getWriteData().chargerData.put(timestamp, chargerVoltage, coilVoltage)
+        writeData.chargerData.put(timestamp, chargerVoltage, coilVoltage)
     }
 
+    @Synchronized
     override fun onWheelDataUpdate(
         timestamp: Long, wheelCountL: Int, wheelCountR: Int,
         wheelDistanceL: Double, wheelDistanceR: Double,
@@ -105,31 +128,35 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
         wheelSpeedBufferedL: Double, wheelSpeedBufferedR: Double,
         wheelSpeedExpAvgL: Double, wheelSpeedExpAvgR: Double
     ) {
-        getWriteData().wheelData.getLeft().put(
+        writeData.wheelData.getLeft().put(
             timestamp, wheelCountL, wheelDistanceL,
             wheelSpeedInstantL, wheelSpeedBufferedL,
             wheelSpeedExpAvgL
         )
-        getWriteData().wheelData.getRight().put(
+        writeData.wheelData.getRight().put(
             timestamp, wheelCountR, wheelDistanceR,
             wheelSpeedInstantR, wheelSpeedBufferedR, wheelSpeedExpAvgR
         )
     }
 
+    @Synchronized
     override fun onImageDataRawUpdate(timestamp: Long, width: Int, height: Int, bitmap: Bitmap) {
-        getWriteData().imageData.add(timestamp, width, height, bitmap, null)
+        val targetIndex = writeIndex
+        writeData.imageData.add(timestamp, width, height, bitmap, null)
         // Handler to compress and put images into buffer
         synchronized(imgCompFuturesTimeStep) {
-            imgCompFuturesTimeStep.add(
-                imageCompressionExecutor.submit {
-                    ImageOps.addCompressedImage2Buffer(
-                        writeIndex,
-                        timestamp,
-                        bitmap,
-                        buffer
-                    )
-                }
-            )
+            val future = imageCompressionExecutor.submit {
+                ImageOps.addCompressedImage2Buffer(
+                    targetIndex,
+                    timestamp,
+                    bitmap,
+                    buffer
+                )
+            }
+            imgCompFuturesTimeStep.add(future)
+            synchronized(imgCompFuturesByIndex[targetIndex]) {
+                imgCompFuturesByIndex[targetIndex].add(future)
+            }
         }
     }
 
@@ -140,16 +167,19 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
         startTime: AudioTimestamp,
         endTime: AudioTimestamp
     ) {
-        getWriteData().soundData.setMetaData(sampleRate, startTime, endTime)
-        getWriteData().soundData.add(audioData, numSamples)
+        synchronized(this) {
+            writeData.soundData.setMetaData(sampleRate, startTime, endTime)
+            writeData.soundData.add(audioData, numSamples)
+        }
     }
 
+    @Synchronized
     override fun onOrientationUpdate(
         timestamp: Long,
         thetaRad: Double,
         angularVelocityRad: Double
     ) {
-        getWriteData().orientationData.put(timestamp, thetaRad, angularVelocityRad)
+        writeData.orientationData.put(timestamp, thetaRad, angularVelocityRad)
     }
 
     override fun onQRCodeDetected(qrDataDecoded: String) {
@@ -196,12 +226,26 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
             orientationData = OrientationData()
         }
 
+        fun freeze() {
+            wheelData.freeze()
+            chargerData.freeze()
+            batteryData.freeze()
+            imageData.freeze()
+            soundData.freeze()
+            orientationData.freeze()
+        }
+
         class WheelData {
             private val left: IndividualWheelData = IndividualWheelData()
             private val right: IndividualWheelData = IndividualWheelData()
 
             fun getLeft() = left
             fun getRight() = right
+
+            fun freeze() {
+                left.freeze()
+                right.freeze()
+            }
 
             class IndividualWheelData {
                 private val timestamps = arrayListOf<Long>()
@@ -210,6 +254,12 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
                 private val speedsInstantaneous = arrayListOf<Double>()
                 private val speedsBuffered = arrayListOf<Double>()
                 private val speedsExpAvg = arrayListOf<Double>()
+                private var timestampSnapshot = LongArray(0)
+                private var countSnapshot = IntArray(0)
+                private var distanceSnapshot = DoubleArray(0)
+                private var speedInstantaneousSnapshot = DoubleArray(0)
+                private var speedBufferedSnapshot = DoubleArray(0)
+                private var speedExpAvgSnapshot = DoubleArray(0)
 
                 fun put(
                     timestamp: Long, count: Int, distance: Double, speedInstantaneous: Double,
@@ -223,12 +273,21 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
                     this.speedsExpAvg.add(speedExpAvg)
                 }
 
-                fun getTimeStamps() = timestamps.toLongArray()
-                fun getCounts() = counts.toIntArray()
-                fun getDistances() = distances.toDoubleArray()
-                fun getSpeedsInstantaneous() = speedsInstantaneous.toDoubleArray()
-                fun getSpeedsBuffered() = speedsBuffered.toDoubleArray()
-                fun getSpeedsExpAvg() = speedsExpAvg.toDoubleArray()
+                fun freeze() {
+                    timestampSnapshot = timestamps.toLongArray()
+                    countSnapshot = counts.toIntArray()
+                    distanceSnapshot = distances.toDoubleArray()
+                    speedInstantaneousSnapshot = speedsInstantaneous.toDoubleArray()
+                    speedBufferedSnapshot = speedsBuffered.toDoubleArray()
+                    speedExpAvgSnapshot = speedsExpAvg.toDoubleArray()
+                }
+
+                fun getTimeStamps() = timestampSnapshot
+                fun getCounts() = countSnapshot
+                fun getDistances() = distanceSnapshot
+                fun getSpeedsInstantaneous() = speedInstantaneousSnapshot
+                fun getSpeedsBuffered() = speedBufferedSnapshot
+                fun getSpeedsExpAvg() = speedExpAvgSnapshot
             }
 
         }
@@ -237,6 +296,9 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
             private val timestamps = arrayListOf<Long>()
             private val chargerVoltage = arrayListOf<Double>()
             private val coilVoltage = arrayListOf<Double>()
+            private var timestampSnapshot = LongArray(0)
+            private var chargerVoltageSnapshot = DoubleArray(0)
+            private var coilVoltageSnapshot = DoubleArray(0)
 
             fun put(timestamp: Long, chargerVoltage: Double, coilVoltage: Double) {
                 this.timestamps.add(timestamp)
@@ -244,22 +306,35 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
                 this.coilVoltage.add(coilVoltage)
             }
 
-            fun getTimeStamps() = timestamps.toLongArray()
-            fun getChargerVoltage() = chargerVoltage.toDoubleArray()
-            fun getCoilVoltage() = coilVoltage.toDoubleArray()
+            fun freeze() {
+                timestampSnapshot = timestamps.toLongArray()
+                chargerVoltageSnapshot = chargerVoltage.toDoubleArray()
+                coilVoltageSnapshot = coilVoltage.toDoubleArray()
+            }
+
+            fun getTimeStamps() = timestampSnapshot
+            fun getChargerVoltage() = chargerVoltageSnapshot
+            fun getCoilVoltage() = coilVoltageSnapshot
         }
 
         class BatteryData {
             private val timestamps = arrayListOf<Long>()
             private val voltage = arrayListOf<Double>()
+            private var timestampSnapshot = LongArray(0)
+            private var voltageSnapshot = DoubleArray(0)
 
             fun put(voltage: Double, timestamp: Long) {
                 this.timestamps.add(timestamp)
                 this.voltage.add(voltage)
             }
 
-            fun getTimeStamps() = timestamps.toLongArray()
-            fun getVoltage() = voltage.toDoubleArray()
+            fun freeze() {
+                timestampSnapshot = timestamps.toLongArray()
+                voltageSnapshot = voltage.toDoubleArray()
+            }
+
+            fun getTimeStamps() = timestampSnapshot
+            fun getVoltage() = voltageSnapshot
         }
 
         class SoundData {
@@ -278,7 +353,9 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
                 private set
 
             private val levels = arrayListOf<Float>()
-            fun getLevels() = levels.toFloatArray()
+            private var levelSnapshot = FloatArray(0)
+
+            fun getLevels() = levelSnapshot
 
             fun add(levels: FloatArray, numSamples: Int) {
                 for (level in levels) {
@@ -299,9 +376,15 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
                 this.sampleRate = sampleRate
                 this.totalSamplesCalculatedViaTime = endTime.framePosition - startTime.framePosition
             }
+
+            fun freeze() {
+                levelSnapshot = levels.toFloatArray()
+            }
         }
 
         class ImageData : Hashtable<Long, SingleImage>() {
+            private var imageSnapshot = ArrayList<SingleImage>()
+
             fun add(
                 timestamp: Long,
                 width: Int,
@@ -318,7 +401,13 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
                 return super.put(key, value)
             }
 
-            val images: ArrayList<SingleImage> get() = ArrayList(this.values)
+            val images: ArrayList<SingleImage>
+                get() = imageSnapshot
+
+            @Synchronized
+            fun freeze() {
+                imageSnapshot = ArrayList(this.values)
+            }
 
             class SingleImage(
                 val timestamp: Long,
@@ -345,6 +434,9 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
             private val timestamps = arrayListOf<Long>()
             private val tiltAngle = arrayListOf<Double>()
             private val angularVelocity = arrayListOf<Double>()
+            private var timestampSnapshot = LongArray(0)
+            private var tiltAngleSnapshot = DoubleArray(0)
+            private var angularVelocitySnapshot = DoubleArray(0)
 
             /**
              * @param timestamp long nano-time
@@ -357,9 +449,15 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
                 this.angularVelocity.add(angularVelocity)
             }
 
-            fun getTimeStamps() = timestamps.toLongArray()
-            fun getTiltAngle() = tiltAngle.toDoubleArray()
-            fun getAngularVelocity() = angularVelocity.toDoubleArray()
+            fun freeze() {
+                timestampSnapshot = timestamps.toLongArray()
+                tiltAngleSnapshot = tiltAngle.toDoubleArray()
+                angularVelocitySnapshot = angularVelocity.toDoubleArray()
+            }
+
+            fun getTimeStamps() = timestampSnapshot
+            fun getTiltAngle() = tiltAngleSnapshot
+            fun getAngularVelocity() = angularVelocitySnapshot
         }
     }
 }

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/TimeStepDataBuffer.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/TimeStepDataBuffer.kt
@@ -41,9 +41,6 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
     val imgCompFuturesTimeStep: MutableCollection<Future<*>> =
         Collections.synchronizedList(LinkedList())
 
-    val imgCompFuturesEpisode: MutableCollection<MutableCollection<Future<*>>> =
-        Collections.synchronizedList(LinkedList())
-
     private val imgCompFuturesByIndex: Array<MutableList<Future<*>>> =
         Array(bufferLength) { Collections.synchronizedList(LinkedList()) }
 
@@ -53,12 +50,6 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
 
     @Synchronized
     fun nextTimeStep() {
-        // Keeps track of how many image compression threads have yet to finish per timestep
-        val completedFutures = getImageCompressionFutures(writeIndex)
-        val episodeFutures = Collections.synchronizedList(LinkedList<Future<*>>())
-        episodeFutures.addAll(completedFutures)
-        imgCompFuturesEpisode.add(episodeFutures)
-
         writeData.freeze()
 
         // Update index for read and write pointer
@@ -282,12 +273,12 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
                     speedExpAvgSnapshot = speedsExpAvg.toDoubleArray()
                 }
 
-                fun getTimeStamps() = timestampSnapshot
-                fun getCounts() = countSnapshot
-                fun getDistances() = distanceSnapshot
-                fun getSpeedsInstantaneous() = speedInstantaneousSnapshot
-                fun getSpeedsBuffered() = speedBufferedSnapshot
-                fun getSpeedsExpAvg() = speedExpAvgSnapshot
+                fun getTimeStamps() = timestampSnapshot.copyOf()
+                fun getCounts() = countSnapshot.copyOf()
+                fun getDistances() = distanceSnapshot.copyOf()
+                fun getSpeedsInstantaneous() = speedInstantaneousSnapshot.copyOf()
+                fun getSpeedsBuffered() = speedBufferedSnapshot.copyOf()
+                fun getSpeedsExpAvg() = speedExpAvgSnapshot.copyOf()
             }
 
         }
@@ -312,9 +303,9 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
                 coilVoltageSnapshot = coilVoltage.toDoubleArray()
             }
 
-            fun getTimeStamps() = timestampSnapshot
-            fun getChargerVoltage() = chargerVoltageSnapshot
-            fun getCoilVoltage() = coilVoltageSnapshot
+            fun getTimeStamps() = timestampSnapshot.copyOf()
+            fun getChargerVoltage() = chargerVoltageSnapshot.copyOf()
+            fun getCoilVoltage() = coilVoltageSnapshot.copyOf()
         }
 
         class BatteryData {
@@ -333,8 +324,8 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
                 voltageSnapshot = voltage.toDoubleArray()
             }
 
-            fun getTimeStamps() = timestampSnapshot
-            fun getVoltage() = voltageSnapshot
+            fun getTimeStamps() = timestampSnapshot.copyOf()
+            fun getVoltage() = voltageSnapshot.copyOf()
         }
 
         class SoundData {
@@ -355,7 +346,7 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
             private val levels = arrayListOf<Float>()
             private var levelSnapshot = FloatArray(0)
 
-            fun getLevels() = levelSnapshot
+            fun getLevels() = levelSnapshot.copyOf()
 
             fun add(levels: FloatArray, numSamples: Int) {
                 for (level in levels) {
@@ -402,7 +393,7 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
             }
 
             val images: ArrayList<SingleImage>
-                get() = imageSnapshot
+                get() = ArrayList(imageSnapshot)
 
             @Synchronized
             fun freeze() {
@@ -455,9 +446,9 @@ class TimeStepDataBuffer(private val bufferLength: Int) : BatteryDataSubscriber,
                 angularVelocitySnapshot = angularVelocity.toDoubleArray()
             }
 
-            fun getTimeStamps() = timestampSnapshot
-            fun getTiltAngle() = tiltAngleSnapshot
-            fun getAngularVelocity() = angularVelocitySnapshot
+            fun getTimeStamps() = timestampSnapshot.copyOf()
+            fun getTiltAngle() = tiltAngleSnapshot.copyOf()
+            fun getAngularVelocity() = angularVelocitySnapshot.copyOf()
         }
     }
 }

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/learning/FlatbufferAssembler.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/learning/FlatbufferAssembler.kt
@@ -77,14 +77,11 @@ class FlatbufferAssembler(
     @Throws(ExecutionException::class, InterruptedException::class)
     fun addTimeStep(timestep: Int) {
         // Wait for image compression to finish before trying to write to flatbuffer
-        synchronized(timeStepDataBuffer.imgCompFuturesTimeStep) {
-            for (future in timeStepDataBuffer.imgCompFuturesTimeStep) {
-                future.get()
-            }
+        for (future in timeStepDataBuffer.getImageCompressionFutures(timestep)) {
+            future.get()
         }
+        val timeStepData = timeStepDataBuffer.getTimeStepData(timestep)
         flatbufferWriteFutures.add(flatBufferWriter.submit {
-            val timeStepData = timeStepDataBuffer.getTimeStepData(timestep)
-
             val wheelData = addWheelData(timeStepData)
             val orientationData = addOrientationData(timeStepData)
             val chargerData = addChargerData(timeStepData)

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/learning/Trial.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/learning/Trial.kt
@@ -175,22 +175,12 @@ open class Trial(
     )
     protected open fun endEpisode() {
         Logger.d("Episode", "End of episode: $episodeCount")
-        // Waits for all image compression to finish prior to finishing flatbuffer
-        val start = System.nanoTime()
-        synchronized(timeStepDataBuffer.imgCompFuturesEpisode) {
-            for (timestepFutures in timeStepDataBuffer.imgCompFuturesEpisode) {
-                synchronized(timestepFutures) {
-                    for (future in timestepFutures) {
-                        future.get()
-                    }
-                }
-            }
-        }
         synchronized(flatBufferAssembler.flatbufferWriteFutures) {
             // Waits for all timestep flatbuffer writes to finish prior to finishing flatbuffer
             for (future in flatBufferAssembler.flatbufferWriteFutures) {
                 future.get()
             }
+            flatBufferAssembler.flatbufferWriteFutures.clear()
         }
         flatBufferAssembler.endEpisode()
         pausePublishers()

--- a/libs/abcvlib/src/test/kotlin/jp/oist/abcvlib/core/inputs/TimeStepDataBufferTest.kt
+++ b/libs/abcvlib/src/test/kotlin/jp/oist/abcvlib/core/inputs/TimeStepDataBufferTest.kt
@@ -1,0 +1,67 @@
+package jp.oist.abcvlib.core.inputs
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+class TimeStepDataBufferTest {
+    @Test
+    fun publicSnapshotArraysCannotMutateFrozenWheelData() {
+        val buffer = TimeStepDataBuffer(bufferLength = 3)
+
+        buffer.onWheelDataUpdate(
+            timestamp = 100L,
+            wheelCountL = 1,
+            wheelCountR = 2,
+            wheelDistanceL = 3.0,
+            wheelDistanceR = 4.0,
+            wheelSpeedInstantL = 5.0,
+            wheelSpeedInstantR = 6.0,
+            wheelSpeedBufferedL = 7.0,
+            wheelSpeedBufferedR = 8.0,
+            wheelSpeedExpAvgL = 9.0,
+            wheelSpeedExpAvgR = 10.0
+        )
+        buffer.nextTimeStep()
+
+        val leftWheelData = buffer.getReadData().wheelData.getLeft()
+        leftWheelData.getTimeStamps()[0] = 999L
+        leftWheelData.getCounts()[0] = 999
+        leftWheelData.getDistances()[0] = 999.0
+        leftWheelData.getSpeedsInstantaneous()[0] = 999.0
+        leftWheelData.getSpeedsBuffered()[0] = 999.0
+        leftWheelData.getSpeedsExpAvg()[0] = 999.0
+
+        assertArrayEquals(longArrayOf(100L), leftWheelData.getTimeStamps())
+        assertArrayEquals(intArrayOf(1), leftWheelData.getCounts())
+        assertArrayEquals(doubleArrayOf(3.0), leftWheelData.getDistances(), 0.0)
+        assertArrayEquals(doubleArrayOf(5.0), leftWheelData.getSpeedsInstantaneous(), 0.0)
+        assertArrayEquals(doubleArrayOf(7.0), leftWheelData.getSpeedsBuffered(), 0.0)
+        assertArrayEquals(doubleArrayOf(9.0), leftWheelData.getSpeedsExpAvg(), 0.0)
+    }
+
+    @Test
+    fun publicSnapshotArraysCannotMutateFrozenBatteryAndOrientationData() {
+        val buffer = TimeStepDataBuffer(bufferLength = 3)
+
+        buffer.onBatteryVoltageUpdate(timestamp = 100L, voltage = 4.2)
+        buffer.onOrientationUpdate(timestamp = 200L, thetaRad = 1.5, angularVelocityRad = 2.5)
+        buffer.nextTimeStep()
+
+        val readData = buffer.getReadData()
+        readData.batteryData.getTimeStamps()[0] = 999L
+        readData.batteryData.getVoltage()[0] = 999.0
+        readData.orientationData.getTimeStamps()[0] = 999L
+        readData.orientationData.getTiltAngle()[0] = 999.0
+        readData.orientationData.getAngularVelocity()[0] = 999.0
+
+        assertArrayEquals(longArrayOf(100L), readData.batteryData.getTimeStamps())
+        assertArrayEquals(doubleArrayOf(4.2), readData.batteryData.getVoltage(), 0.0)
+        assertArrayEquals(longArrayOf(200L), readData.orientationData.getTimeStamps())
+        assertArrayEquals(doubleArrayOf(1.5), readData.orientationData.getTiltAngle(), 0.0)
+        assertArrayEquals(
+            doubleArrayOf(2.5),
+            readData.orientationData.getAngularVelocity(),
+            0.0
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- publish immutable timestep snapshots from the data buffer
- update flatbuffer assembly to consume the snapshot-oriented flow

## Notes
This is the timestep data consistency slice of the larger `tutorial` branch.

## Tests
Not run; branch split only.