### PR TITLE
Stop background serial state polling

### DIFF
--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/SerialCommManager.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/util/SerialCommManager.kt
@@ -60,16 +60,15 @@ open class SerialCommManager @JvmOverloads constructor(
         while (!context.stopRequested.get()) {
             val nextCommand = try {
                 synchronized(commandLock) {
-                    // this results in getState commands every 10ms unless another command
-                    // (e.g. setMotorLevels) is set, which case wait will return immediately
-                    if (command == null)
-                        commandLock.wait(context.delay.get())
+                    while (command == null && !context.stopRequested.get()) {
+                        commandLock.wait()
+                    }
 
                     if (context.stopRequested.get()) {
                         return@synchronized null
                     }
 
-                    val localCommand = command ?: RP2040OutgoingCommand.GetState()
+                    val localCommand = command ?: return@synchronized null
                     command = null
                     localCommand
                 }


### PR DESCRIPTION
## Summary
- stop default background `GET_STATE` polling in `SerialCommManager`
- keep serial traffic tied to explicit command requests

## Notes
This is the serial behavior slice of the larger `tutorial` branch. It intentionally does not reintroduce the older byte-array parsing/logging code.

## Tests
Not run; branch split only.