### PR TITLE
Update BasicAssembler wheel metrics

### DIFF
--- a/apps/basicAssembler/src/main/java/jp/oist/abcvlib/basicassembler/MainActivity.kt
+++ b/apps/basicAssembler/src/main/java/jp/oist/abcvlib/basicassembler/MainActivity.kt
@@ -44,8 +44,8 @@ import kotlin.time.Duration.Companion.milliseconds
 class MainActivity : AbcvlibActivity(), SerialReadyListener {
     private lateinit var binding: ActivityMainBinding
     private lateinit var guiUpdater: GuiUpdater
-    private val maxEpisodeCount = 3
-    private val maxTimeStepCount = 40
+    private val maxEpisodeCount = 5
+    private val maxTimeStepCount = 50
     private lateinit var stateSpace: StateSpace
     private lateinit var actionSpace: ActionSpace
     private lateinit var timeStepDataBuffer: TimeStepDataBuffer
@@ -92,8 +92,8 @@ class MainActivity : AbcvlibActivity(), SerialReadyListener {
         val motionActionSpace = MotionActionSpace(5).apply {
             // I'm just overwriting an existing to show how
             addMotionAction("stop", 0.toByte(), 0f, 0f, false, false)
-            addMotionAction("forward", 1.toByte(), 1f, 1f, false, false)
-            addMotionAction("backward", 2.toByte(), -1f, -1f, false, false)
+            addMotionAction("forward", 1.toByte(), 0.75f, 0.75f, false, false)
+            addMotionAction("backward", 2.toByte(), -0.75f, -0.75f, false, false)
             addMotionAction("left", 3.toByte(), -1f, 1f, false, false)
             addMotionAction("right", 4.toByte(), 1f, -1f, false, false)
         }
@@ -107,8 +107,8 @@ class MainActivity : AbcvlibActivity(), SerialReadyListener {
 
         val publisherManager = PublisherManager()
         val wheelData = WheelData.Builder(this, publisherManager)
-            .setBufferLength(50)
-            .setExpWeight(0.01)
+            .setBufferLength(10)
+            .setExpWeight(0.1)
             .build()
         wheelData.addSubscriber(timeStepDataBuffer)
 

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/microcontroller/WheelData.kt
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/inputs/microcontroller/WheelData.kt
@@ -24,7 +24,7 @@ class WheelData(
         private val publisherManager: PublisherManager
     ) {
         private var bufferLength = 50
-        private var expWeight = 0.01
+        private var expWeight = 0.1
 
         fun build(): WheelData {
             return WheelData(context, publisherManager, bufferLength, expWeight)
@@ -63,7 +63,7 @@ class WheelData(
      *    when creating an instance of WheelData.
      *
      * 3. [SingleWheelData.speedExponentialAvg] is a running exponential average of
-     *    [SingleWheelData.speedBuffered]. The default weight of the average is 0.01, but this
+     *    [SingleWheelData.speedBuffered]. The default weight of the average is 0.1, but this
      *    can be set via the [WheelData] constructor or via the [WheelData.Builder.setExpWeight]
      *    builder method when creating an instance of WheelData.
      *
@@ -78,16 +78,15 @@ class WheelData(
             leftWheel.update(timestamp, countL)
             if (!paused) {
                 for (subscriber in subscribers) {
-                    // The right encoder counts in the opposite direction because the wheels are
-                    // physically mirrored. Negate right-wheel metrics here so subscriber-facing
-                    // APIs report positive values for forward motion on both sides.
+                    // Firmware now reports right-wheel encoder direction in the same
+                    // subscriber-facing convention as the left wheel.
                     subscriber.onWheelDataUpdate(
                         timestamp, leftWheel.latestEncoderCount,
-                        -rightWheel.latestEncoderCount, leftWheel.latestDistance,
-                        -rightWheel.latestDistance, leftWheel.speedInstantaneous,
-                        -rightWheel.speedInstantaneous, leftWheel.speedBuffered,
-                        -rightWheel.speedBuffered, leftWheel.speedExponentialAvg,
-                        -rightWheel.speedExponentialAvg
+                        rightWheel.latestEncoderCount, leftWheel.latestDistance,
+                        rightWheel.latestDistance, leftWheel.speedInstantaneous,
+                        rightWheel.speedInstantaneous, leftWheel.speedBuffered,
+                        rightWheel.speedBuffered, leftWheel.speedExponentialAvg,
+                        rightWheel.speedExponentialAvg
                     )
                 }
             }
@@ -198,15 +197,17 @@ class WheelData(
         fun updateWheelSpeed(timestamp: Long) {
             timestamps[idxHead] = timestamp
             val dtBuffer = ((timestamps[idxHead] - timestamps[idxTail]) / 1000000000f).toDouble()
+            val dtInstant =
+                ((timestamps[idxHead] - timestamps[idxHeadPrev]) / 1000000000f).toDouble()
 
-            if (dtBuffer != 0.0) {
+            if (dtBuffer != 0.0 && dtInstant != 0.0) {
                 // Calculate the speed of each wheel in mm/s.
-                speedInstantaneous = (distance[idxHead] - distance[idxHeadPrev]) / 1000000000f
+                speedInstantaneous = (distance[idxHead] - distance[idxHeadPrev]) / dtInstant
                 speedBuffered = (distance[idxHead] - distance[idxTail]) / dtBuffer
                 speedExponentialAvg =
                     DSP.exponentialAvg(speedBuffered, speedExponentialAvg, expWeight)
             } else {
-                Logger.i("sensorDebugging", "dt_buffer == 0")
+                Logger.i("sensorDebugging", "dt_buffer or dt_instant == 0")
             }
         }
 


### PR DESCRIPTION
## Summary
- update wheel metric calculations/conventions
- adjust BasicAssembler usage of the wheel data values

## Notes
This is the wheel metrics slice of the larger `tutorial` branch and affects the data shown/used by BasicAssembler.

## Tests
Not run; branch split only.