### PR TITLE
Allow collaborators to trigger Codex review

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -56,7 +56,7 @@ jobs:
           script: |
             const eventName = context.eventName;
             const expectedCommand = '#codex-review';
-            const expectedAssociations = ['MEMBER', 'OWNER'];
+            const expectedAssociations = ['COLLABORATOR', 'MEMBER', 'OWNER'];
             const isIssueComment = eventName === 'issue_comment';
             const isPullRequestComment = Boolean(context.payload.issue?.pull_request);
             const receivedCommentBody = context.payload.comment?.body ?? '';


### PR DESCRIPTION
## Summary
- allow `COLLABORATOR` author association through the Codex review trust gate
- keep `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, and untrusted associations excluded

## Reason
The Codex PR Review workflow skipped trusted PRs when GitHub reported the author association as `COLLABORATOR` at event time.

## Tests
Not run; workflow configuration change only.