### PR TITLE
Fix BasicAssembler motion block timestep off-by-one

### DIFF
--- a/apps/basicAssembler/src/main/java/jp/oist/abcvlib/basicassembler/MyTrial.kt
+++ b/apps/basicAssembler/src/main/java/jp/oist/abcvlib/basicassembler/MyTrial.kt
@@ -26,7 +26,8 @@ class MyTrial(
     private val mainHandler: Handler = Handler(context.mainLooper)
 
     override fun forward(data: TimeStepData) {
-        val motionAction: MotionAction = if ((timeStep / 10) % 2 == 0) {
+        val actionIndex = (timeStep - 1).coerceAtLeast(0) / 10
+        val motionAction: MotionAction = if (actionIndex % 2 == 0) {
             motionActionSet.motionActions[1]!!
         } else {
             motionActionSet.motionActions[2]!!


### PR DESCRIPTION
## Summary
- What is in scope for this PR?
Fix BasicAssembler motion block timestep off-by-one
- [x] I have read and agree to follow `docs/PR_WORKFLOW.md` for this PR.

## Scope Declaration
- Exact slice/module in this PR:
  - `apps/basicAssembler/src/main/java/jp/oist/abcvlib/basicassembler/MyTrial.kt`
- Related sibling PRs/issues (remaining slices), if any:
  - #279 
